### PR TITLE
Add bandit pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,9 +43,13 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.12.0
+    rev: v1.14.0
     hooks:
       - id: pyupgrade
+  - repo: https://github.com/PyCQA/bandit
+    rev: 2a1dbab
+    hooks:
+      - id: bandit
   - repo: https://github.com/ambv/black
     rev: 19.3b0
     hooks:


### PR DESCRIPTION
Also ran `pre-commit autoupdate`, which picked up a newer version of the pyupgrade hook.