### PR TITLE
Add pydoc warnings to flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,6 +3,8 @@ max-line-length = 80
 # Select (turn on)
 # * Complexity violations reported by mccabe (C) -
 #   http://flake8.pycqa.org/en/latest/user/error-codes.html#error-violation-codes
+# * Documentation conventions compliance reported by pydocstyle (D) -
+#   http://www.pydocstyle.org/en/stable/error_codes.html
 # * Default errors and warnings reported by pycodestyle (E and W) -
 #   https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
 # * Default errors reported by pyflakes (F) -
@@ -11,7 +13,7 @@ max-line-length = 80
 #   https://github.com/PyCQA/flake8-bugbear#list-of-warnings
 # * The B950 flake8-bugbear opinionated warning -
 #   https://github.com/PyCQA/flake8-bugbear#opinionated-warnings
-select = C,E,F,W,B,B950
+select = C,D,E,F,W,B,B950
 # Ignore flake8's default warning about maximum line length, which has
 # a hard stop at the configured value.  Instead we use
 # flake8-bugbear's B950, which allows up to 10% overage.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,8 @@ repos:
     rev: 3.7.7
     hooks:
       - id: flake8
+        additional_dependencies:
+          - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
     rev: v1.14.0
     hooks:


### PR DESCRIPTION
Also add `flake8-docstrings` as an additional dependency in the `.pre-commit-config.yml` file.