### PR TITLE
Improvement bandit config

### DIFF
--- a/.bandit.yml
+++ b/.bandit.yml
@@ -1,7 +1,7 @@
 # Configuration file for the Bandit python security scanner
 # https://bandit.readthedocs.io/en/latest/config.html
 
-# Test are first included by `tests`, and then excluded by `skips`.
+# Tests are first included by `tests`, and then excluded by `skips`.
 # If `tests` is empty, all tests are are considered included.
 
 tests:

--- a/.bandit.yml
+++ b/.bandit.yml
@@ -1,0 +1,12 @@
+# Configuration file for the Bandit python security scanner
+# https://bandit.readthedocs.io/en/latest/config.html
+
+# Test are first included by `tests`, and then excluded by `skips`.
+# If `tests` is empty, all tests are are considered included.
+
+tests:
+  #- B101
+  #- B102
+
+skips:
+  #- B101 # skip "assert used" check since assertions are required in pytests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,8 @@ repos:
     rev: 2a1dbab
     hooks:
       - id: bandit
+        args:
+          - --config=.bandit.yml
   - repo: https://github.com/ambv/black
     rev: 19.3b0
     hooks:


### PR DESCRIPTION
I found it useful to have a configuration for `bandit` when using `pytest` since `B101`  causes a lot of trouble.  

I don't think this needs to be pushed to all the projects, but it probably should get pulled to the family of skeletons.  ☠️ 

By default I've left all the tests enable, and left hints how to config them. 