### PR TITLE
Make .bandit.yml pass yamllint

### DIFF
--- a/.bandit.yml
+++ b/.bandit.yml
@@ -1,3 +1,4 @@
+---
 # Configuration file for the Bandit python security scanner
 # https://bandit.readthedocs.io/en/latest/config.html
 
@@ -5,8 +6,8 @@
 # If `tests` is empty, all tests are are considered included.
 
 tests:
-  #- B101
-  #- B102
+# - B101
+# - B102
 
 skips:
-  #- B101 # skip "assert used" check since assertions are required in pytests
+# - B101 # skip "assert used" check since assertions are required in pytests


### PR DESCRIPTION
When molecule runs in cisagov/skeleton-role-ansible, the yamllint stage fails because of `.bandit.yml`.  It seems appropriate to fix it here.