### PR TITLE
Use TravisCI caching to speed up builds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.1
+    rev: v2.2.3
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -23,7 +23,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.15.0
+    rev: v0.16.0
     hooks:
       - id: markdownlint
         # The LICENSE.md must match the license text exactly for
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
-    rev: 1.0.4
+    rev: 1.0.5
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
@@ -45,11 +45,11 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.16.3
+    rev: v1.17.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
-    rev: 2a1dbab
+    rev: 1.6.0
     hooks:
       - id: bandit
         args:
@@ -74,6 +74,6 @@ repos:
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier
-    rev: 1.17.0
+    rev: 1.17.1
     hooks:
       - id: prettier

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,14 @@
 dist: xenial
 language: python
 python: 3.7
+# pre-commit hooks can use Docker, so we should go ahead and enable it
 services: docker
+
+# Cache pip packages and pre-commit plugins to speed up builds
+cache:
+  pip: true
+  directories:
+    - $HOME/.cache/pre-commit
 
 install:
   - pip install --upgrade -r requirements-test.txt


### PR DESCRIPTION
I modified the TravisCI config to use caching to speed up builds.  I am caching the pip packages and the pre-commit plugins.  You can read about TravisCI's caching [here](https://docs.travis-ci.com/user/caching/).  For this repository it appears to cut the build time in half if the cache is completely up to date.

I also went ahead and ran `pre-commit autoupdate` to pick up the latest version of the pre-commit plugins.

Once this PR is approved and merged I will percolate the changes down to the other skeletons.