### PR TITLE
Configure prettier to ignore JSON files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
+# Already being linted by pretty-format-json
+*.json
 # Already being linted by mdl
 *.md
 # Already being linted by yamllint


### PR DESCRIPTION
JSON files are already being linted by the `pretty-format-json` hook, which conflicts with the prettier hook.