### PR TITLE
Re-enable ansible-lint and autoupgrade.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v2.4.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -23,7 +23,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.18.0
+    rev: v0.19.0
     hooks:
       - id: markdownlint
         args:
@@ -37,13 +37,13 @@ repos:
     hooks:
       - id: shell-lint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.8
+    rev: 3.7.9
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.25.0
+    rev: v1.25.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -53,15 +53,14 @@ repos:
         args:
           - --config=.bandit.yml
   - repo: https://github.com/python/black
-    rev: 19.3b0
+    rev: 19.10b0
     hooks:
       - id: black
-  # Disabled until: https://github.com/ansible/ansible-lint/issues/590
-  # - repo: https://github.com/ansible/ansible-lint.git
-  #   rev: v4.1.1a0
-  #   hooks:
-  #     - id: ansible-lint
-  #       # files: molecule/default/playbook.yml
+  - repo: https://github.com/ansible/ansible-lint.git
+    rev: v4.1.1a3
+    hooks:
+      - id: ansible-lint
+        # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
     rev: v1.12.0
     hooks:


### PR DESCRIPTION
This PR re-enables ansible-lint because the fix for #19 in https://github.com/cisagov/skeleton-packer/pull/20 is in release [v4.1.1a2](https://github.com/ansible/ansible-lint/releases/tag/v4.1.1a2)+

Other hooks have been updated because of a flake8 bug detailed in [merge request #367](https://gitlab.com/pycqa/flake8/merge_requests/367) and [issue #587](https://gitlab.com/pycqa/flake8/issues/587) which was resolved in [release 3.7.9](https://flake8.pycqa.org/en/3.7.9/release-notes/3.7.9.html).