### PR TITLE
Add GitHub action caching of pre-commit hooks and pip packages.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,7 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v1
 
@@ -15,6 +13,25 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.7
+
+      - name: Cache pre-commit hooks
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pre-commit
+          key: "${{ runner.os }}-pre-commit-\
+            ${{ hashFiles('**/.pre-commit-config.yaml') }}"
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-
+
+      - name: Cache pip test requirements
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: "${{ runner.os }}-pip-test-\
+            ${{ hashFiles('**/requirements-test.txt') }}"
+          restore-keys: |
+            ${{ runner.os }}-pip-test-
+            ${{ runner.os }}-pip-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,6 @@ jobs:
           path: ~/.cache/pre-commit
           key: "${{ runner.os }}-pre-commit-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
-          restore-keys: |
-            ${{ runner.os }}-pre-commit-
 
       - name: Cache pip test requirements
         uses: actions/cache@v1


### PR DESCRIPTION
Caching should reduce the test time of this repo from 4 minutes to less than 1.5.  

See: 
 - https://help.github.com/en/github/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows