### PR TITLE
Add isort tool to pre-commit hooks.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,12 @@
+[settings]
+combine_star=true
+force_sort_within_sections=true
+
+import_heading_stdlib=Standard Python Libraries
+import_heading_thirdparty=Third-Party Libraries
+import_heading_firstparty=cisagov Libraries
+
+# Should be auto-populated by seed-isort-config hook
+known_third_party=
+# These must be manually set to correctly separate them from third party libraries
+known_first_party=

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,16 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
+  - repo: https://github.com/asottile/seed-isort-config
+    rev: v1.9.3
+    hooks:
+      - id: seed-isort-config
+  - repo: https://github.com/pre-commit/mirrors-isort
+    # pick the isort version you'd like to use from
+    # https://github.com/pre-commit/mirrors-isort/releases
+    rev: v4.3.21
+    hooks:
+      - id: isort
   - repo: https://github.com/ansible/ansible-lint.git
     rev: v4.1.1a5
     hooks:


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds the isort and related seed-isort-config hooks to the pre-commit configuration.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Since we already use the `black` tool to standardize code formatting for Python it makes sense to automatically standardize imports in a similar way. This is done using the [`isort`](https://github.com/timothycrosley/isort) tool and enhanced with the [`seed-isort-config`](https://github.com/asottile/seed-isort-config) tool to statically populate third-party packages in the isort configuration file `.isort.cfg`. The caveat is that first-party packages must be explicitly defined in the configuration file to correctly be separated. These tools are implemented as `pre-commit` hooks to be run with the rest of our `pre-commit` suite.

This PR was originally intended for [cisagov/skeleton-python-library](https://github.com/cisagov/skeleton-python-library), but due to some good feedback from @jsf9k I am moving it to this repo and will then update downstream to get the benefits.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I tested it on the [cisagov/skeleton-python-library](https://github.com/cisagov/skeleton-python-library) and [cisagov/cyhy-feeds](https://github.com/cisagov/cyhy-feeds) projects to ensure behavior was as expected.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
