### PR TITLE
Make workflow run when a PR is opened, synchronized, or reopened

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,10 @@
 ---
 name: build
 
-on: [push, pull_request]
+on: [
+  push,
+  pull_request
+]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 ---
 name: build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
## 🗣 Description

Add the `pull_request` event type so that, when a user forks a cisagov repo and creates a pull request to merge changes back into the cisagov repo, the required GitHub Action workflows are run.

## 💭 Motivation and Context

A user forked [cisagov/scan-target-data](https://github.com/cisagov/scan-target-data) and created [a pull request](https://github.com/cisagov/scan-target-data/pull/14), but the required GitHub Action(s) did not run.  This is presumably because the user does not have Actions enabled in his or her fork.  Ideally, the required Action(s) would run in the corresponding cisagov repo when a PR to merge changes back in is created.  Based on my reading of [the documentation](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#pull-request-events-for-forked-repositories), adding the `pull_request` event type should make this happen.

## 🧪 Testing

I forked this repo and created [a test pull request](https://github.com/cisagov/skeleton-generic/pull/30) and was able to verify that the required workflow now runs.  In addition, all the pre-commit hooks pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
