### PR TITLE
Update Python and actions/checkout Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,20 +10,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
-
+          python-version: 3.8
       - name: Cache pre-commit hooks
         uses: actions/cache@v1
         with:
           path: ~/.cache/pre-commit
           key: "${{ runner.os }}-pre-commit-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
-
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
@@ -33,11 +29,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-test-
             ${{ runner.os }}-pip-
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r requirements-test.txt
-
       - name: Run pre-commit on all files
         run: pre-commit run --all-files


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This small PR updates the Python version from 3.7 to 3.8 and updates the GitHub Actions workflow to use [actions/checkout](https://github.com/actions/checkout) from v1 to  [v2](https://github.com/actions/checkout/releases/tag/v2.0.0). The formatting was also updated to reflect how the workflow file is formatted downstream.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
Downstream skeletons are already using Python 3.8 in many cases so it makes sense to have the base skeleton also use Python 3.8. There are some performance improvements and new features in actions/checkout@v2, and the only removed feature was using `submodules` so it made sense to update.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I forked [cisagov/check-cve-2019-19781](https://github.com/cisagov/check-cve-2019-19781/) and updated its workflows to use Python 3.8 and actions/checkout@v2. All workflows ran as expected and there were no issues with the changes implemented.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
