### PR TITLE
Update pre-commit hooks (and flip Actions cache order in workflow).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,6 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - name: Cache pre-commit hooks
-        uses: actions/cache@v1
-        with:
-          path: ~/.cache/pre-commit
-          key: "${{ runner.os }}-pre-commit-\
-            ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
@@ -29,6 +23,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-test-
             ${{ runner.os }}-pip-
+      - name: Cache pre-commit hooks
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pre-commit
+          key: "${{ runner.os }}-pre-commit-\
+            ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-json
@@ -27,13 +27,13 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.19.0
+    rev: v0.22.0
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.json
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.18.0
+    rev: v1.20.0
     hooks:
       - id: yamllint
   - repo: https://github.com/detailyang/pre-commit-shell
@@ -47,7 +47,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.25.1
+    rev: v1.26.2
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -61,7 +61,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.3
+    rev: v1.9.4
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/pre-commit/mirrors-isort
@@ -71,7 +71,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.1.1a5
+    rev: v4.2.0
     hooks:
       - id: ansible-lint
         # files: molecule/default/playbook.yml
@@ -81,7 +81,7 @@ repos:
       - id: terraform_fmt
       - id: terraform_validate_no_variables
   - repo: https://github.com/IamTheFij/docker-pre-commit
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: docker-compose-check
   - repo: https://github.com/prettier/prettier


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR has updated `pre-commit` hooks from running `pre-commit autoupdate` to get the freshest checks for our codebases. I also noticed that the order for cache retrieval in our GitHub Actions workflow is reversed from downstream skeletons. In downstream projects the order is `pip` and then `pre-commit`, while in this skeleton it is `pre-commit` and then `pip`. I flipped the order to be lined up with how we are doing it elsewhere.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
The last time we updated our `pre-commit` hooks was November of last year so I thought it was time for an update. Since there are other changes that will need to propagate downstream they may as well include updated `pre-commit` hooks.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
There were no issues within this project when running the new hooks. I then ran it against other skeleton projects with `pre-commit run --files` and there was no unexpected behavior.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
