### PR TITLE
Autoupdate pre-commit hooks.  Add mypy.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         additional_dependencies:
           - flake8-docstrings
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.0.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/PyCQA/bandit
@@ -74,7 +74,7 @@ repos:
     rev: v4.2.0
     hooks:
       - id: ansible-lint
-        # files: molecule/default/playbook.yml
+      # files: molecule/default/playbook.yml
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
     rev: v1.12.0
     hooks:
@@ -88,3 +88,7 @@ repos:
     rev: 1.19.1
     hooks:
       - id: prettier
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.761
+    hooks:
+      - id: mypy


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

<!--- Describe your changes in detail -->
Sister to PR https://github.com/cisagov/skeleton-python-library/pull/37 
Add [mypy](https://github.com/python/mypy) static type checker to the pre-commit hooks. ([cherry-pick](https://git-scm.com/docs/git-cherry-pick)) 🍒

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I can across a section of the [18-F Python development guide](https://engineering.18f.gov/python/) that discussed static checking.  There are a lot of upsides to type hinting and few downsides.  Also I miss the safety of a statically-typed language. 

As mentioned in the 18-F guide (and soon our own): 

> ...It’s reasonable to default to using type annotations when they make your intent clearer (i.e. as a form of documentation). We suggest using a static analysis tool to catch logic bugs, but only where it’s practical. 


## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Previous tests pass.

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
