### PR TITLE
Incorporate the Python version into keys for pip and pre-commit caches.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,20 +14,25 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
+      - name: Store installed Python version
+        run: |
+          echo "::set-env name=PY_VERSION::"\
+          "$(python -c "import platform;print(platform.python_version())")"
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
           path: ~/.cache/pip
-          key: "${{ runner.os }}-pip-test-\
+          key: "${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}"
           restore-keys: |
+            ${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-
             ${{ runner.os }}-pip-test-
             ${{ runner.os }}-pip-
       - name: Cache pre-commit hooks
         uses: actions/cache@v1
         with:
           path: ~/.cache/pre-commit
-          key: "${{ runner.os }}-pre-commit-\
+          key: "${{ runner.os }}-pre-commit-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Install dependencies
         run: |


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR adds the Python version installed in the environment into the key used for `pip` and `pre-commit` caches.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
This should resolve the issue seen in https://github.com/cisagov/ansible-role-kali/actions/runs/48995345 where the Python version has updated before any changes to `.pre-commit-config.yml` have occurred. This results in a `pre-commit` cache that points to a Python version no longer installed. This should prevent such an issue from recurring in the future.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
Automated tests ran with no issues. I confirmed in the Action logs that a new cache was generated on the new key.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
