### PR TITLE
Change Cache Paths to Environment Variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on: [
   pull_request
 ]
 
+env:
+  PIP_CACHE_DIR: ~/.cache/pip
+  PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,7 +25,7 @@ jobs:
       - name: Cache pip test requirements
         uses: actions/cache@v1
         with:
-          path: ~/.cache/pip
+          path: ${{ env.PIP_CACHE_DIR }}
           key: "${{ runner.os }}-pip-test-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}"
           restore-keys: |
@@ -31,7 +35,7 @@ jobs:
       - name: Cache pre-commit hooks
         uses: actions/cache@v1
         with:
-          path: ~/.cache/pre-commit
+          path: ${{ env.PRE_COMMIT_CACHE_DIR }}
           key: "${{ runner.os }}-pre-commit-py${{ env.PY_VERSION }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
       - name: Install dependencies


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This small PR changes the cache path definitions to use `env` variables. This aligns the topmost skeleton with how children skeleton define the cache path.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
When merging in the `pre-commit` fix in #37 downstream I noticed that derived skeleton repos define the cache path in `env` variables. This made merging more complicated than it needed to be so I decided to realign the topmost skeleton repository with how others are organized.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
Automated testing passed with no issues.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
