### PR TITLE
Add setuptools and wheel as pip dependencies

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,2 @@
+--requirement requirements.txt
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+setuptools
+wheel


### PR DESCRIPTION
## 🗣 Description

This pull request adds `setuptools` and `wheel` as `pip` dependencies.

## 💭 Motivation and Context

`setuptools` usually comes along with `pip`, but `wheel` does not.  Using `wheel` where possible to build python extensions is more modern and more security conscious than using the old-style `setup.py` that `pip` reverts to if `wheel` is not installed.

While we're adding `wheel`, we may as well add `setuptools` for good measure.

## 🧪 Testing

All the pre-commit hooks pass.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
