### PR TITLE
Workflow improvements: 🦁 set-env, and 🐯 python-3.9, and 🐻 dependabot, oh my! 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+---
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Store installed Python version
         run: |
           echo "::set-env name=PY_VERSION::"\

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,9 @@ jobs:
           python-version: 3.9
       - name: Store installed Python version
         run: |
-          echo "::set-env name=PY_VERSION::"\
-          "$(python -c "import platform;print(platform.python_version())")"
+          echo "PY_VERSION="\
+          "$(python -c "import platform;print(platform.python_version())")" \
+          >> $GITHUB_ENV
       - name: Cache linting environments
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

<!--- Describe your changes in detail -->
This PR changes three things:
 - It bumps the build workflow Python version to [3.9](https://github.com/actions/setup-python/issues/148).
 - It enables weekly [dependabot](https://github.com/features/security#security-alert) scanning for `pip` and `github-actions`.
 - It replaces the [deprecated `set-env` syntax](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) with the [new `$GITHUB_ENV` file](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable). 

## 💭 Motivation and Context

The motivation is two-fold:
 - General care and feeding of our skeleton crop.
 - Getting a more robust dependency management policy started for the cisagov organization.   This should help mitigate some of the dependency bit rot we're starting to see in some of our projects.  A normal cadence of dependency update PRs triggered by `dependabot` will also help us identify the repositories that are ripe for archiving to the [permafrost vaults of Svalbard](https://www.youtube.com/watch?v=fzI9FNjXQ0o). 🏔️ 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have verified in my own clone that `dependabot` will not be opening any PRs during its initial scan.

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
