### PR TITLE
Change repo for the prettier pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,8 +93,8 @@ repos:
     rev: v2.0.0
     hooks:
       - id: docker-compose-check
-  - repo: https://github.com/prettier/prettier
-    rev: 2.1.2
+  - repo: https://github.com/prettier/pre-commit
+    rev: v2.1.2
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This PR changes the repo used to reference the [`prettier`](https://github.com/prettier/prettier) hook for `pre-commit`.
<!--- Describe your changes in detail -->

## 💭 Motivation and Context

@dav3r noticed an issue setting up the `prettier` hook when working with the current batch of `lineage` PRs going out. Upon investigating he found that per https://github.com/prettier/prettier/issues/9459, and specifically https://github.com/prettier/prettier/issues/9459#issuecomment-713223710, the `pre-commit` functionality for the `prettier` hook is being broken out into its own repo.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

`pre-commit` runs successfully with the new configuration.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
