### PR TITLE
Ensure that the cisagov devs are the owners of the .github directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,10 @@
 # Each line is a file pattern followed by one or more owners.
 
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# these owners will be requested for review when someone
-# opens a pull request.
+# These owners will be the default owners for everything in the
+# repo. Unless a later match takes precedence, these owners will be
+# requested for review when someone opens a pull request.
 * @dav3r @felddy @hillaryj @jsf9k @mcdonnnj
+
+# These folks own any files in the /.github directory at the root of
+# the repository and any of its subdirectories.
+/.github/ @dav3r @felddy @hillaryj @jsf9k @mcdonnnj

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,6 @@
 # requested for review when someone opens a pull request.
 * @dav3r @felddy @hillaryj @jsf9k @mcdonnnj
 
-# These folks own any files in the /.github directory at the root of
+# These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.
 /.github/ @dav3r @felddy @hillaryj @jsf9k @mcdonnnj


### PR DESCRIPTION
## 🗣 Description

This pull request adds an additional clause at the end of the `CODEOWNERS` file that ensures that the `cisagov` devs retain control of the `.github` directory.   Note that this additional clause must remain at the _end_ of the `CODEOWNERS` file so that it cannot be overridden by a later clause.

## 💭 Motivation and Context

We want to make it so that all the `.github` files including `CODEOWNERS` are protected so only code owners (the dev team) can approve modifications to them.

This will prevent configuration changes from breaking Actions and other management-type functions that the files in this directory control. By setting the `.github` files/folder to require code owner approval for changes, workflow and management changes will require dev team review and checking.

Resolves #56.

## 🧪 Testing

I don't know how to really test these changes.

## 🚥 Types of Changes

- New feature (non-breaking change which adds functionality)
- Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
