### PR TITLE
Use the python version output by actions/setup-python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,26 +16,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - id: setup-python
+        uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Store installed Python version
-        run: |
-          echo "PY_VERSION="\
-          "$(python -c "import platform;print(platform.python_version())")" \
-          >> $GITHUB_ENV
       - name: Cache linting environments
         uses: actions/cache@v2
         with:
           path: |
             ${{ env.PIP_CACHE_DIR }}
             ${{ env.PRE_COMMIT_CACHE_DIR }}
-          key: "lint-${{ runner.os }}-py${{ env.PY_VERSION }}-\
+          key: |
+            lint-${{ runner.os }}-\
+            py${{ steps.setup-python.outputs.python-version }}-\
             ${{ hashFiles('**/requirements-test.txt') }}-\
             ${{ hashFiles('**/requirements.txt') }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
           restore-keys: |
-            lint-${{ runner.os }}-py${{ env.PY_VERSION }}-
+            lint-${{ runner.os }}-\
+            py${{ steps.setup-python.outputs.python-version }}-
             lint-${{ runner.os }}-
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the GitHub Actions workflow in `build.yml` to use the python version output by [the `actions/setup-python` action](https://github.com/actions/setup-python) instead of running python code to determine the python version.

Resolves #58.

## 💭 Motivation and Context ##

There is no need to run python code to determine the python version.  [The python version is already being output by the `setup-python` action](https://github.com/actions/setup-python/blob/main/action.yml#L14-L16), which we are already using.

## 🧪 Testing ##

I ran the workflow with these changes and verified that `${{ steps.setup-python.outputs.python-version }}` indeed contains the python version - currently `3.9.0`.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
