### PR TITLE
Remove Trailing Quotation Mark from Actions Cache Key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           path: |
             ${{ env.PIP_CACHE_DIR }}
             ${{ env.PRE_COMMIT_CACHE_DIR }}
-          key: |
+          key: |-
             lint-${{ runner.os }}-\
             py${{ steps.setup-python.outputs.python-version }}-\
             ${{ hashFiles('**/requirements-test.txt') }}-\

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
             py${{ steps.setup-python.outputs.python-version }}-\
             ${{ hashFiles('**/requirements-test.txt') }}-\
             ${{ hashFiles('**/requirements.txt') }}-\
-            ${{ hashFiles('**/.pre-commit-config.yaml') }}"
+            ${{ hashFiles('**/.pre-commit-config.yaml') }}
           restore-keys: |
             lint-${{ runner.os }}-\
             py${{ steps.setup-python.outputs.python-version }}-


### PR DESCRIPTION
## 🗣 Description ##

This PR removes a trailing quotation mark from the `lint` job's `actions/cache` key. It also removes the trailing newline (`\n`) added by switching to the block scalar format (`|`).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

in #59 the value for the `actions/cache` key was changed to use the pipe form for block scalars, but in the process the ending quotation mark was not removed.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I confirmed that the key being used by the action no longer has a trailing quotation mark.

### Last Merged PR Run ###

https://github.com/cisagov/skeleton-generic/runs/1419430869?check_suite_focus=true#step:4:6

```console
key: lint-Linux-\
  py3.9.0-\
  4d6c2ba2786097c74dca7abc3707d576242350073cf738b69537399d20cd487c-\
  c2a90360b9139caea83bba3d7e2739e350b7e3aa53efe7922108b2b44325c3ee-\
  ac3b46e98deceeb8fd1f101d93a2b45598b68a7975471a0d63d052e0b2f20ca8"
  
restore-keys: lint-Linux-\
```

### Last `apb` Run ###

https://github.com/cisagov/skeleton-generic/runs/1381786531?check_suite_focus=true#step:5:6

```console
key: lint-Linux-py3.9.0-4d6c2ba2786097c74dca7abc3707d576242350073cf738b69537399d20cd487c-c2a90360b9139caea83bba3d7e2739e350b7e3aa53efe7922108b2b44325c3ee-9ff6996b601c7d804757a92c10ff7756d543bded97848e5705c3034c17535606
restore-keys: lint-Linux-py3.9.0
```

### Latest Run for This PR ###

https://github.com/cisagov/skeleton-generic/runs/1425159070?check_suite_focus=true#step:4:6

```console
key: lint-Linux-\
  py3.9.0-\
  4d6c2ba2786097c74dca7abc3707d576242350073cf738b69537399d20cd487c-\
  c2a90360b9139caea83bba3d7e2739e350b7e3aa53efe7922108b2b44325c3ee-\
  ac3b46e98deceeb8fd1f101d93a2b45598b68a7975471a0d63d052e0b2f20ca8
restore-keys: lint-Linux-\
```

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
