### PR TITLE
Improve actions/cache Configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,22 +20,20 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Cache linting environments
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
+        env:
+          BASE_CACHE_KEY: "${{ github.job }}-${{ runner.os }}-\
+            py${{ steps.setup-python.outputs.python-version }}-"
         with:
           path: |
             ${{ env.PIP_CACHE_DIR }}
             ${{ env.PRE_COMMIT_CACHE_DIR }}
-          key: |
-            lint-${{ runner.os }}-\
-            py${{ steps.setup-python.outputs.python-version }}-\
+          key: "${{ env.BASE_CACHE_KEY }}\
             ${{ hashFiles('**/requirements-test.txt') }}-\
             ${{ hashFiles('**/requirements.txt') }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
           restore-keys: |
-            lint-${{ runner.os }}-\
-            py${{ steps.setup-python.outputs.python-version }}-
-            lint-${{ runner.os }}-
+            ${{ env.BASE_CACHE_KEY }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR reorganizes our [actions/cache](https://github.com/actions/cache) configuration in workflows. This includes:

* Replace the hard-coded job reference with the `github.job` context value.
* Set a step environment value with the base cache key to allow reuse.
* Make the `restore-keys` input sane by only allowing a suitable partial match.

This PR would replace #61 .
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

After the last kraken batch I noticed a lot of issues with the cache keys being used by [actions/cache](https://github.com/actions/cache) as a result of how values are parsed. In the case of the `key`, block scalars end up with newlines in the cache key. Also the `restore-keys` value cannot differentiate between continuations and individual values using a block scalar. Lastly, we should only restore a cache that matches the program versions being used. Previously this allowed a fallback to a cache that matched only the `<job name>-<runner.os>`, which is undesirable.

An example of an undesirable `restore-keys` hit:

```console
Run actions/cache@v2
  with:
    path: ~/.cache/pip
    key: test-Linux-py3.6.12-b10b9a24ca1842893422d02422df870668d7c087e3e94943728fe5c67b750d4d-8480ac675d7d1691e48580f45eaac4fb101cc8c312561d12012ab900c88a7e06
    restore-keys: test-Linux-\
  py3.6.12-
  test-Linux-
  
  env:
    PIP_CACHE_DIR: ~/.cache/pip
    PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
    pythonLocation: /opt/hostedtoolcache/Python/3.6.12/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.6.12/x64/lib
Received 19828851 of 19828851 (100.0%), 63.5 MBs/sec
Cache Size: ~19 MB (19828851 B)
/bin/tar --use-compress-program zstd -d -xf /home/runner/work/_temp/09759f61-7304-4b99-8fda-f5605650c688/cache.tzst -P -C /home/runner/work/skeleton-python-library/skeleton-python-library
Cache restored from key: test-Linux-py3.9-b10b9a24ca1842893422d02422df870668d7c087e3e94943728fe5c67b750d4d-8480ac675d7d1691e48580f45eaac4fb101cc8c312561d12012ab900c88a7e06
```

Additionally, setting this up to be more modular will make it easier to switch to use [YAML 1.2 anchors](https://yaml.org/spec/1.2/spec.html#id2765878) if GHA adds support for that in workflow syntax.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I confirmed that values are as expected for `key` and `restore-keys` inputs. Key values for the push containing these changes:

```console
key: lint-Linux-py3.9.0-4d6c2ba2786097c74dca7abc3707d576242350073cf738b69537399d20cd487c-c2a90360b9139caea83bba3d7e2739e350b7e3aa53efe7922108b2b44325c3ee-ac3b46e98deceeb8fd1f101d93a2b45598b68a7975471a0d63d052e0b2f20ca8
restore-keys: lint-Linux-py3.9.0-
```

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
