### PR TITLE
Add the pre-commit-packer Repo and Hooks to the pre-commit Configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,3 +113,10 @@ repos:
     rev: v2.0.0
     hooks:
       - id: docker-compose-check
+
+  # Packer hooks
+  - repo: https://github.com/cisagov/pre-commit-packer
+    rev: v0.0.2
+    hooks:
+      - id: packer_validate
+      - id: packer_fmt


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds [cisagov/pre-commit-packer](https://github.com/cisagov/pre-commit-packer/) as a repo with hooks under a new section in our `pre-commit` configuration for [Packer](https://github.com/hashicorp/packer).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

I noticed that we did not have any kind of [Packer](https://github.com/hashicorp/packer) hooks in our existing `pre-commit` configuration. After some searching I was unable to find any helpful hooks that already existed. I decided to write one instead to provide automated checking with the `packer validate` and `packer fmt` commands.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I did some local testing against [cisagov/skeleton-packer](https://github.com/cisagov/skeleton-packer) and a [cisagov/cyhy_amis](https://github.com/cisagov/cyhy_amis) branch that I'm using to test the result of `packer hcl2_upgrade` after being inspired by https://github.com/cisagov/skeleton-packer/issues/64. When added, the correct files were checked and appropriate failures were observed when breaking changes were added.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
