### PR TITLE
Add the validate_manifest Hook to pre-commit Configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,12 @@ repos:
         args:
           - --strict
 
+  # pre-commit hooks
+  - repo: https://github.com/pre-commit/pre-commit
+    rev: v2.13.0
+    hooks:
+      - id: validate_manifest
+
   # Shell script hooks
   - repo: https://github.com/lovesegfault/beautysh
     rev: v6.1.0


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the `validate_manifest` hook from [pre-commit/pre-commit](https://github.com/pre-commit/pre-commit).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I have created two dedicated [pre-commit](https://pre-commit.com) repos ([cisagov/pre-commit-packer](https://github.com/cisagov/pre-commit-packer) and [cisagov/pre-commit-shfmt](https://github.com/cisagov/pre-commit-shfmt)) and we may add hook configurations to other projects (such as a Python project). This hook will validate that a [pre-commit](https://pre-commit.com) hook manifest is valid.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
I tested it in the two aforementioned repositories and it had no issues with the manifests.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
