### PR TITLE
Use the hashicorp/setup-terraform Action to Install Terraform in GHA Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,17 +75,9 @@ jobs:
             ${{ env.CURL_CACHE_DIR }}/"${PACKER_ZIP}"
           sudo mv /usr/local/bin/packer /usr/local/bin/packer-default
           sudo ln -s /opt/packer/packer /usr/local/bin/packer
-      - name: Install Terraform
-        run: |
-          TERRAFORM_ZIP="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
-          curl --output ${{ env.CURL_CACHE_DIR }}/"${TERRAFORM_ZIP}" \
-            --time-cond ${{ env.CURL_CACHE_DIR }}/"${TERRAFORM_ZIP}" \
-            --location \
-            "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_ZIP}"
-          sudo unzip -d /opt/terraform \
-            ${{ env.CURL_CACHE_DIR }}/"${TERRAFORM_ZIP}"
-          sudo mv /usr/local/bin/terraform /usr/local/bin/terraform-default
-          sudo ln -s /opt/terraform/terraform /usr/local/bin/terraform
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
       - name: Install shfmt
         run: go install mvdan.cc/sh/v3/cmd/shfmt@${SHFMT_VERSION}
       - name: Install Terraform-docs


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR switches to using the [hashicorp/setup-terraform](https://github.com/hashicorp/setup-terraform) Action to install Terraform. This closes #86 .
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Using a well maintained Action to install Terraform is preferable to our manual installation because we will likely see easier maintainability this way. In the words of one of my favorite programmers: "Why roll your own when you can get it from the source?"! 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automatic tests pass. You can see in [this Action run](https://github.com/cisagov/skeleton-generic/runs/3287138980?check_suite_focus=true#step:13:28) that the version specified by [cisagov/setup-env-github-action](https://github.com/cisagov/setup-env-github-action) is installed.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
