### PR TITLE
Enable terraform validate pre-commit hook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: cisagov/setup-env-github-action@improvement/support_tf_0.13
+      - uses: cisagov/setup-env-github-action@develop
       - uses: actions/checkout@v2
       - id: setup-python
         uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,13 +84,6 @@ jobs:
         run: |
           go install \
             github.com/terraform-docs/terraform-docs@${TERRAFORM_DOCS_VERSION}
-      - name: Find and initialize Terraform directories
-        run: |
-          for path in $(find . -not \( -type d -name ".terraform" -prune \) \
-            -type f -iname "*.tf" -exec dirname "{}" \; | sort -u); do \
-            echo "Initializing '$path'..."; \
-            terraform init -input=false -backend=false "$path"; \
-            done
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: cisagov/setup-env-github-action@develop
+      - uses: cisagov/setup-env-github-action@improvement/support_tf_0.13
       - uses: actions/checkout@v2
       - id: setup-python
         uses: actions/setup-python@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,22 +117,7 @@ repos:
     rev: v1.50.0
     hooks:
       - id: terraform_fmt
-      # There are ongoing issues with how this command works. This issue
-      # documents the core issue:
-      # https://github.com/hashicorp/terraform/issues/21408
-      # We have seen issues primarily with proxy providers and Terraform code
-      # that uses remote state. The PR
-      # https://github.com/hashicorp/terraform/pull/24887
-      # has been approved and is part of the 0.13 release to resolve the issue
-      # with remote states.
-      # The PR
-      # https://github.com/hashicorp/terraform/pull/24896
-      # is a proprosed fix to deal with `terraform validate` with proxy
-      # providers (among other configurations).
-      # We have decided to disable the terraform_validate hook until the issues
-      # above have been resolved, which we hope will be with the release of
-      # Terraform 0.13.
-      # - id: terraform_validate
+      - id: terraform_validate
 
   # Docker hooks
   - repo: https://github.com/IamTheFij/docker-pre-commit


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR enables the `terraform validate` pre-commit hook.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

That pre-commit hook had been disabled in all of our repositories because of issues related to proxy providers and Terraform code that uses remote state.  We believe that those issues (see https://github.com/hashicorp/terraform/pull/24887 and https://github.com/hashicorp/terraform/pull/24896) have been corrected in Terraform 0.13.x, which we are in the process of migrating to, so this hook should now work as expected in most, if not all of our repos.

This PR will remain `blocked` until the following conditions have been met:
* [x] All of our repositories that use Terraform have been successfully updated to use Terraform 0.13.x.
* [x] All of our deployed Terraform states have been updated to Terraform 0.13.x.  **It is important to note that we cannot update any Terraform states to 0.14.x until they successfully apply with 0.13.x first.**
* [x] https://github.com/cisagov/setup-env-github-action/pull/37 has been approved and merged.

This PR is a part of cisagov/cool-system#94.  

Similar PRs are:
* cisagov/skeleton-tf-module#57
* cisagov/skeleton-packer#82
* cisagov/skeleton-ansible-role-with-test-user#24

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I verified that running `terraform validate` with Terraform 0.13.7 works without any errors in this repository.  I also confirmed that all pre-commit hooks (including the newly-enabled `terraform validate` hook) run successfully.

After I confirmed that pre-commit with Terraform 0.13.7 ran successfully in GitHub Actions via https://github.com/cisagov/skeleton-generic/pull/90/commits/6a7fbf07bd371d0493c523ce24647e5c04c77c03, I reverted that commit (see https://github.com/cisagov/skeleton-generic/pull/90/commits/b51dbb577e02baff361a6494e22f61aa517e28d4) in preparation for when this PR becomes unblocked at the end of downstream testing.

Further testing will be done in all downstream repositories.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.