### PR TITLE
Use Outputs of cisagov/setup-env-github-action to Control Installed Program Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           BASE_CACHE_KEY: "${{ github.job }}-${{ runner.os }}-\
             py${{ steps.setup-python.outputs.python-version }}-\
             go${{ env.GO_VERSION }}-\
-            packer${{ env.PACKER_VERSION }}-\
+            packer${{ steps.setup-env.outputs.packer-version }}-\
             tf${{ steps.setup-env.outputs.terraform-version }}-"
         with:
           # Note that the .terraform directory IS NOT included in the
@@ -66,6 +66,8 @@ jobs:
       - name: Setup curl cache
         run: mkdir -p ${{ env.CURL_CACHE_DIR }}
       - name: Install Packer
+        env:
+          PACKER_VERSION: ${{ steps.setup-env.outputs.packer-version }}
         run: |
           PACKER_ZIP="packer_${PACKER_VERSION}_linux_amd64.zip"
           curl --output ${{ env.CURL_CACHE_DIR }}/"${PACKER_ZIP}" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
             py${{ steps.setup-python.outputs.python-version }}-\
             go${{ env.GO_VERSION }}-\
             packer${{ env.PACKER_VERSION }}-\
-            tf${{ env.TERRAFORM_VERSION }}-"
+            tf${{ steps.setup-env.outputs.terraform-version }}-"
         with:
           # Note that the .terraform directory IS NOT included in the
           # cache because if we were caching, then we would need to use
@@ -78,7 +78,7 @@ jobs:
           sudo ln -s /opt/packer/packer /usr/local/bin/packer
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          terraform_version: ${{ steps.setup-env.outputs.terraform-version }}
       - name: Install shfmt
         run: go install mvdan.cc/sh/v3/cmd/shfmt@${SHFMT_VERSION}
       - name: Install Terraform-docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,16 +24,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      # GO_VERSION and GOCACHE are used by the cache task, so the Go
-      # installation must happen before that.
+      # We need the Go version and Go cache location for the actions/cache step,
+      # so the Go installation must happen before that.
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16'
       - name: Store installed Go version
+        id: go-version
         run: |
-          echo "GO_VERSION="\
-          "$(go version | sed 's/^go version go\([0-9.]\+\) .*/\1/')" \
-          >> $GITHUB_ENV
+          echo "::set-output name=version::"\
+          "$(go version | sed 's/^go version go\([0-9.]\+\) .*/\1/')"
       - name: Lookup Go cache directory
         id: go-cache
         run: |
@@ -42,7 +42,7 @@ jobs:
         env:
           BASE_CACHE_KEY: "${{ github.job }}-${{ runner.os }}-\
             py${{ steps.setup-python.outputs.python-version }}-\
-            go${{ env.GO_VERSION }}-\
+            go${{ steps.go-version.outputs.version }}-\
             packer${{ steps.setup-env.outputs.packer-version }}-\
             tf${{ steps.setup-env.outputs.terraform-version }}-"
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,10 @@ jobs:
         with:
           terraform_version: ${{ steps.setup-env.outputs.terraform-version }}
       - name: Install shfmt
-        run: go install mvdan.cc/sh/v3/cmd/shfmt@${SHFMT_VERSION}
+        env:
+          PACKAGE_URL: mvdan.cc/sh/v3/cmd/shfmt
+          PACKAGE_VERSION: ${{ steps.setup-env.outputs.shfmt-version }}
+        run: go install ${PACKAGE_URL}@${PACKAGE_VERSION}
       - name: Install Terraform-docs
         run: |
           go install \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: cisagov/setup-env-github-action@develop
+      - id: setup-env
+        uses: cisagov/setup-env-github-action@develop
       - uses: actions/checkout@v2
       - id: setup-python
         uses: actions/setup-python@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,9 +87,10 @@ jobs:
           PACKAGE_VERSION: ${{ steps.setup-env.outputs.shfmt-version }}
         run: go install ${PACKAGE_URL}@${PACKAGE_VERSION}
       - name: Install Terraform-docs
-        run: |
-          go install \
-            github.com/terraform-docs/terraform-docs@${TERRAFORM_DOCS_VERSION}
+        env:
+          PACKAGE_URL: github.com/terraform-docs/terraform-docs
+          PACKAGE_VERSION: ${{ steps.setup-env.outputs.terraform-docs-version }}
+        run: go install ${PACKAGE_URL}@${PACKAGE_VERSION}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the `lint` job to use the outputs of [cisagov/setup-env-github-action](https://github.com/cisagov/setup-env-github-action) that were added in https://github.com/cisagov/setup-env-github-action/pull/40 to control what program versions are installed.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Now that [cisagov/setup-env-github-action](https://github.com/cisagov/setup-env-github-action) has outputs we can move away from using environment variables for the entire `job` context. This reduces the cluttering of environment variables in the steps for the job and reduces the likelihood off colliding with an environment variable on the system where the steps are running.

Line length limits for `yamllint` do result in the use of some step-specific environment variables. I can disable linting or add a step with output as a workaround if we'd prefer to eliminate those instances.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass and I checked the Action logs to make sure expected versions were in use.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
