### PR TITLE
Update the `ansible-lint` Version in the pre-commit Configuration

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,22 @@
+---
+# See https://ansible-lint.readthedocs.io/en/latest/configuring.html
+# for a list of the configuration elements that can exist in this
+# file.
+enable_list:
+  # Useful checks that one must opt-into.  See here for more details:
+  # https://ansible-lint.readthedocs.io/en/latest/rules.html
+  - fcqn-builtins
+  - no-log-password
+  - no-same-owner
+exclude_paths:
+  # This exclusion is implicit, unless exclude_paths is defined
+  - .cache
+  # Seems wise to ignore this too
+  - .github
+  # ansible-lint doesn't like the role name in this playbook, but it's
+  # what molecule requires
+  - molecule/default/converge.yml
+  # These two are Molecule configuration files, not Ansible playbooks
+  - molecule/default/molecule-no-systemd.yml
+  - molecule/default/molecule-with-systemd.yml
+use_default_rules: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,9 +105,7 @@ repos:
 
   # Ansible hooks
   - repo: https://github.com/ansible-community/ansible-lint
-    # This is intentionally being held back because of issues in v5 per
-    # https://github.com/cisagov/skeleton-ansible-role/issues/69
-    rev: v4.3.7
+    rev: v5.2.1
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the version pin for [ansible-lint](https://github.com/ansible-community/ansible-lint) in our [pre-commit](https://pre-commit.com) configuration to the latest version. A `.ansible-lint` configuration file is added to go along with this change.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This PR ties in with https://github.com/cisagov/skeleton-ansible-role/pull/85 to update the version of [ansible-lint](https://github.com/ansible-community/ansible-lint) we use for our repositories.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Automated tests pass.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
