### PR TITLE
Update the `ansible-lint` hook for `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,7 +105,7 @@ repos:
 
   # Ansible hooks
   - repo: https://github.com/ansible-community/ansible-lint
-    rev: v5.2.1
+    rev: v5.3.2
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the version of [ansible-lint] used in our [pre-commit] configuration to the latest release.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This change is necessary because [ansible-lint] has loosely pinned the [rich] package, and in the v11 release a breaking change was introduced. This was reported in https://github.com/ansible-community/ansible-lint/issues/1795, and the [5.3.2 release](https://github.com/ansible-community/ansible-lint/releases/tag/v5.3.2) included updates for compatibility with [rich] v11.

The breaking change resulted in workflows that didn't have cached [pre-commit] environments failing linting at the [ansible-lint] hook:

```console
Ansible-lint.............................................................Failed
- hook id: ansible-lint
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repo40qn8w4j/py_env-python3/bin/ansible-lint", line 8, in <module>
    sys.exit(_run_cli_entrypoint())
  File "/home/runner/.cache/pre-commit/repo40qn8w4j/py_env-python3/lib/python3.9/site-packages/ansiblelint/__main__.py", line 299, in _run_cli_entrypoint
    sys.exit(main(sys.argv))
  File "/home/runner/.cache/pre-commit/repo40qn8w4j/py_env-python3/lib/python3.9/site-packages/ansiblelint/__main__.py", line 211, in main
    from ansiblelint.generate_docs import rules_as_rich, rules_as_rst, rules_as_str
  File "/home/runner/.cache/pre-commit/repo40qn8w4j/py_env-python3/lib/python3.9/site-packages/ansiblelint/generate_docs.py", line 6, in <module>
    from rich.console import render_group
ImportError: cannot import name 'render_group' from 'rich.console' (/home/runner/.cache/pre-commit/repo40qn8w4j/py_env-python3/lib/python3.9/site-packages/rich/console.py)
```
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I tested it locally and the freshly built [ansible-lint] environment ran without issue.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[ansible-lint]: https://github.com/ansible-community/ansible-lint
[pre-commit]: https://pre-commit.com
[rich]: https://github.com/Textualize/rich