### PR TITLE
Update the `line-length` configuration for `yamllint`

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -8,6 +8,14 @@ rules:
   # this behavior.
   comments-indentation: disable
 
+  # yamllint does not allow inline mappings that exceed the line length by
+  # default. There are many scenarios where the inline mapping may be a key,
+  # hash, or other long value that would exceed the line length but cannot
+  # reasonably be broken across lines.
+  line-length:
+    # This rule implies the allow-non-breakable-words rule
+    allow-non-breakable-inline-mappings: true
+
   # yamllint doesn't like when we use yes and no for true and false,
   # but that's pretty standard in Ansible.
   truthy: disable

--- a/.yamllint
+++ b/.yamllint
@@ -15,7 +15,8 @@ rules:
   line-length:
     # This rule implies the allow-non-breakable-words rule
     allow-non-breakable-inline-mappings: true
-
+    # Allows a 10% overage from the default limit of 80
+    max: 88
   # yamllint doesn't like when we use yes and no for true and false,
   # but that's pretty standard in Ansible.
   truthy: disable


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request modifies the default rules that [yamllint](https://github.com/adrienverge/yamllint) has for `line-length`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We sometimes run afoul of the line length rules with common use-cases that cannot be readily broken up across multiple lines. This change gives us more flexibility in dealing with those as well as giving a 10% overage on line length that mirrors tools we use such as [black](https://github.com/psf/black).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that the configuration worked as expected against a YAML file.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
