### PR TITLE
Update two configuration files

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,66 +2,66 @@
 # Rather than breaking up descriptions into multiline strings we disable that
 # specific rule in yamllint for this file.
 # yamllint disable rule:line-length
-- color: "#eb6420"
+- color: "eb6420"
   description: This issue or pull request is awaiting the outcome of another issue or pull request
   name: blocked
-- color: "#000000"
+- color: "000000"
   description: This issue or pull request involves changes to existing functionality
   name: breaking change
-- color: "#d73a4a"
+- color: "d73a4a"
   description: This issue or pull request addresses broken functionality
   name: bug
-- color: "#07648d"
+- color: "07648d"
   description: This issue will be advertised on code.gov's Open Tasks page (https://code.gov/open-tasks)
   name: code.gov
-- color: "#0366d6"
+- color: "0366d6"
   description: Pull requests that update a dependency file
   name: dependencies
-- color: "#5319e7"
+- color: "5319e7"
   description: This issue or pull request improves or adds to documentation
   name: documentation
-- color: "#cfd3d7"
+- color: "cfd3d7"
   description: This issue or pull request already exists or is covered in another issue or pull request
   name: duplicate
-- color: "#b005bc"
+- color: "b005bc"
   description: A high-level objective issue encompassing multiple issues instead of a specific unit of work
   name: epic
-- color: "#000000"
+- color: "000000"
   description: Pull requests that update GitHub Actions code
   name: github-actions
-- color: "#0e8a16"
+- color: "0e8a16"
   description: This issue or pull request is well-defined and good for newcomers
   name: good first issue
-- color: "#ff7518"
+- color: "ff7518"
   description: Pull request that should count toward Hacktoberfest participation
   name: hacktoberfest-accepted
-- color: "#a2eeef"
+- color: "a2eeef"
   description: This issue or pull request will add or improve functionality, maintainability, or ease of use
   name: improvement
-- color: "#fef2c0"
+- color: "fef2c0"
   description: This issue or pull request is not applicable, incorrect, or obsolete
   name: invalid
-- color: "#ce099a"
+- color: "ce099a"
   description: This pull request is ready to merge during the next Lineage Kraken release
   name: kraken 🐙
-- color: "#a4fc5d"
+- color: "a4fc5d"
   description: This issue or pull request requires further information
   name: need info
-- color: "#fcdb45"
+- color: "fcdb45"
   description: This pull request is awaiting an action or decision to move forward
   name: on hold
-- color: "#ef476c"
+- color: "ef476c"
   description: This issue is a request for information or needs discussion
   name: question
-- color: "#00008b"
+- color: "00008b"
   description: This issue or pull request adds or otherwise modifies test code
   name: test
-- color: "#1d76db"
+- color: "1d76db"
   description: This issue or pull request pulls in upstream updates
   name: upstream update
-- color: "#d4c5f9"
+- color: "d4c5f9"
   description: This issue or pull request increments the version number
   name: version bump
-- color: "#ffffff"
+- color: "ffffff"
   description: This issue will not be incorporated
   name: wontfix

--- a/.yamllint
+++ b/.yamllint
@@ -17,6 +17,7 @@ rules:
     allow-non-breakable-inline-mappings: true
     # Allows a 10% overage from the default limit of 80
     max: 88
+
   # yamllint doesn't like when we use yes and no for true and false,
   # but that's pretty standard in Ansible.
   truthy: disable


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request fixes the `labels.yml` configuration file that defines repository labels and adds a missing empty line to the `.yamllint` configuration file.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The color values previously had a leading `#` in them since they are hex values but this causes the color values to be interpreted as invalid by the GitHub API. I confirmed that with the `#` removed labels are correctly updated and synchronized.

The empty line in the `.yamllint` file just makes the spacing consistent with what was already there.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified the color value change works by changing them and disabling the dry run in the workflow in https://github.com/cisagov/pre-commit-shfmt/actions/runs/3429891724. The labels were correctly synchronized with those changes in place.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
