### PR TITLE
Add a lower bound for the version of setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
-setuptools
+# setuptools<65.5.1 has an inefficient regex vulnerability that
+# *could* lead to DoS:
+# - https://security.snyk.io/vuln/SNYK-PYTHON-SETUPTOOLS-3113904
+# - pypa/setuptools#3659
+# - https://cwe.mitre.org/data/definitions/1333.html
+setuptools>=65.5.1
 wheel


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a lower bound for the version of setuptools.

## 💭 Motivation and context ##

This is done in response to a recently-discovered vulnerability in setuptools:
- https://security.snyk.io/vuln/SNYK-PYTHON-SETUPTOOLS-3113904
- pypa/setuptools#3659
- https://cwe.mitre.org/data/definitions/1333.html

It should also get rid of a zillion Snyk PRs [like this](https://github.com/cisagov/ansible-role-apt-over-https/pull/7) that are polluting our repos.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.