### PR TITLE
Add a security label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -53,6 +53,9 @@
 - color: "ef476c"
   description: This issue is a request for information or needs discussion
   name: question
+- color: "d73a4a"
+  description: This issue or pull request addresses a security issue
+  name: security
 - color: "00008b"
   description: This issue or pull request adds or otherwise modifies test code
   name: test


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a security label.

## 💭 Motivation and context ##

I was working on cisagov/ansible-role-burp-suite-pro#51 when it occurred to me that such a label would be nice to have around to apply to that PR and others in the future.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.