### PR TITLE
Install/upgrade setuptools and wheel when upgrading pip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
         run: go install ${PACKAGE_URL}@${PACKAGE_VERSION}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           pip install --upgrade --requirement requirements-test.txt
       - name: Set up pre-commit hook environments
         run: pre-commit install-hooks


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Python package installation to install/upgrade `setuptools` and `wheel` when upgrading `pip`, just before installing any project-specific Python dependencies.

## 💭 Motivation and context ##

When `wheel` gets installed _along with_ other packages, it may not get used when those other packages are installed.  When that happens I see warnings [like this](https://github.com/cisagov/ansible-role-freeipa-server/actions/runs/4264190034/jobs/7421929771#step:13:210):
```
DEPRECATION: ansible-core is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option. Discussion can be found at https://github.com/pypa/pip/issues/8559
```

This change should get rid of these warnings.  Note that these warnings do not appear in this project, but they do appear in repos based on downstream skeleton repositories.

Nota bene: This is the practice we follow in the Dockerfile in cisagov/skeleton-docker, but for some reason we never started using it in our workflows.

## 🧪 Testing ##

All automated testing passes.  I no longer see the warning mentioned above in the GitHub Actions output.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.