### PR TITLE
Fix two broken links

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,10 +1,9 @@
 ---
-# See https://ansible-lint.readthedocs.io/en/latest/configuring.html
-# for a list of the configuration elements that can exist in this
-# file.
+# See https://ansible-lint.readthedocs.io/configuring/ for a list of
+# the configuration elements that can exist in this file.
 enable_list:
   # Useful checks that one must opt-into.  See here for more details:
-  # https://ansible-lint.readthedocs.io/en/latest/rules.html
+  # https://ansible-lint.readthedocs.io/rules/
   - fcqn-builtins
   - no-log-password
   - no-same-owner


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes two broken links in `.ansible-lint`.

## 💭 Motivation and context ##

Resolves cisagov/skeleton-generic#131.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.