### PR TITLE
Use the correct repo name for the ansible-lint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -130,7 +130,7 @@ repos:
       - id: pyupgrade
 
   # Ansible hooks
-  - repo: https://github.com/ansible-community/ansible-lint
+  - repo: https://github.com/ansible/ansible-lint
     rev: v6.17.0
     hooks:
       - id: ansible-lint


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `pre-commit` configuration to use the correct name for the `ansible-lint` pre-commit hook.

## 💭 Motivation and context ##

The repo name we were using redirects to the correct place, but we may as well cut out the middle man.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.