### PR TITLE
Delete duplicate word "are"

### DIFF
--- a/.bandit.yml
+++ b/.bandit.yml
@@ -3,7 +3,7 @@
 # https://bandit.readthedocs.io/en/latest/config.html
 
 # Tests are first included by `tests`, and then excluded by `skips`.
-# If `tests` is empty, all tests are are considered included.
+# If `tests` is empty, all tests are considered included.
 
 tests:
 # - B101


### PR DESCRIPTION
## 🗣 Description ##

This pull request deletes a duplicated word in a comment in a configuration file.

## 💭 Motivation and context ##

Removing the duplicated word reduces confusion and increases grammatical correctness.

## 🧪 Testing ##

I did extensive testing using my ocular orbs.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.