### PR TITLE
Add a job that runs diagnostics

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
     #   - dependency-name: actions/setup-go
     #   - dependency-name: actions/setup-python
     #   - dependency-name: crazy-max/ghaction-github-labeler
+    #   - dependency-name: crazy-max/ghaction-github-status
     #   - dependency-name: hashicorp/setup-terraform
     #   - dependency-name: mxschmitt/action-tmate
     package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
     #   - dependency-name: crazy-max/ghaction-github-status
     #   - dependency-name: hashicorp/setup-terraform
     #   - dependency-name: mxschmitt/action-tmate
+    #   - dependency-name: step-security/harden-runner
     package-ecosystem: github-actions
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     #   - dependency-name: actions/checkout
     #   - dependency-name: actions/setup-go
     #   - dependency-name: actions/setup-python
+    #   - dependency-name: crazy-max/ghaction-dump-context
     #   - dependency-name: crazy-max/ghaction-github-labeler
     #   - dependency-name: crazy-max/ghaction-github-status
     #   - dependency-name: hashicorp/setup-terraform

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,11 @@ jobs:
       - diagnostics
     runs-on: ubuntu-latest
     steps:
+      - id: harden-runner
+        name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - id: setup-env
         uses: cisagov/setup-env-github-action@develop
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   diagnostics:
+    name: Run diagnostics
     runs-on: ubuntu-latest
     steps:
       - id: github-status

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,12 @@ env:
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
 
 jobs:
+  diagnostics:
+    runs-on: ubuntu-latest
+    steps:
+      - id: github-status
+        name: Check GitHub status
+        uses: crazy-max/ghaction-github-status@v3
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
       - id: github-status
         name: Check GitHub status
         uses: crazy-max/ghaction-github-status@v3
+      - id: dump-context
+        name: Dump context
+        uses: crazy-max/ghaction-dump-context@v2
   lint:
     needs:
       - diagnostics

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,11 @@ jobs:
     name: Run diagnostics
     runs-on: ubuntu-latest
     steps:
+      - id: harden-runner
+        name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - id: github-status
         name: Check GitHub status
         uses: crazy-max/ghaction-github-status@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
         name: Check GitHub status
         uses: crazy-max/ghaction-github-status@v3
   lint:
+    needs:
+      - diagnostics
     runs-on: ubuntu-latest
     steps:
       - id: setup-env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     name: Run diagnostics
     runs-on: ubuntu-latest
     steps:
+      # Note that a duplicate of this step must be added at the top of
+      # each job.
       - id: harden-runner
         name: Harden the runner
         uses: step-security/harden-runner@v2


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a `diagnostics` job that runs these GitHub Actions:
- [crazy-max/ghaction-github-status](https://github.com/crazy-max/ghaction-github-status)
- [crazy-max/ghaction-dump-context](https://github.com/crazy-max/ghaction-dump-context)
- [step-security/harden-runner](https://github.com/step-security/harden-runner)

## 💭 Motivation and context ##

The GitHub Actions listed above are added in a separate `diagnostics` job.  As configured the actions should never fail, but they will print out information that may be useful in diagnosing workflow failures.

## 🧪 Testing ##

All automated tests pass.  I verified that the expected outputs appear in [the GitHub Actions log](https://github.com/cisagov/skeleton-generic/actions/runs/6026498448/job/16349578787?pr=144) (also [here](https://github.com/cisagov/skeleton-generic/actions/runs/6027704202/job/16353486732?pr=144)).

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.