### PR TITLE
Add a diagnostics job for the label syncing workflow

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -11,7 +11,26 @@ permissions:
   contents: read
 
 jobs:
+  diagnostics:
+    name: Run diagnostics
+    runs-on: ubuntu-latest
+    steps:
+      # Note that a duplicate of this step must be added at the top of
+      # each job.
+      - id: harden-runner
+        name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - id: github-status
+        name: Check GitHub status
+        uses: crazy-max/ghaction-github-status@v3
+      - id: dump-context
+        name: Dump context
+        uses: crazy-max/ghaction-dump-context@v2
   labeler:
+    needs:
+      - diagnostics
     permissions:
       # actions/checkout needs this to fetch code
       contents: read
@@ -19,6 +38,11 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
+      - id: harden-runner
+        name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v4
       - name: Sync repository labels
         if: success()


### PR DESCRIPTION
Also add a runner hardening task to the labeler job.

## 🗣 Description ##

This pull request adds a `diagnostics` job to the `sync-labels.yml` workflow.  It also adds a runner hardening task to the `labeler` job in that workflow.

## 💭 Motivation and context ##

This agrees with the changes we made to the `build.yml` workflow in #144.  I believe such changes should be made globally to all of our workflows, with the goal of eventually changing the runner hardening task to enforce (as opposed to audit) the hardening rules.

## 🧪 Testing ##

All automated tests pass.  I examined the results of the workflow runs with my ocular orbs.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.