### PR TITLE
Make the dev team the owners of the linter configuration files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,12 @@
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.
 /.github/ @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+
+# These folks own all linting configuration files.
+/.*.cfg @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/.*.yaml @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/.*.yml @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/.ansible-lint @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/.flake8 @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/.prettierignore @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/.yamllint @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,5 @@
 /.flake8 @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
 /.prettierignore @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
 /.yamllint @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/requirements*.txt @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/setup-env @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,12 +10,15 @@
 /.github/ @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
 
 # These folks own all linting configuration files.
-/.*.cfg @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
-/.*.yaml @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
-/.*.yml @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
 /.ansible-lint @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/.bandit.yml @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
 /.flake8 @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/.isort.cfg @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/.mdl_config.yaml @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/.pre-commit-config.yaml @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
 /.prettierignore @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
 /.yamllint @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
-/requirements*.txt @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/requirements.txt @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/requirements-dev.txt @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/requirements-test.txt @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
 /setup-env @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds some lines to the `CODEOWNERS` file that make the dev team the owners of the linter configuration files.

## 💭 Motivation and context ##

We don't want folks removing or modifying the linters without @cisagov/team-ois knowing.  Resolves #73.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.