### PR TITLE
Allow setup-env to specify Python version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,12 @@ There are a few ways to do this, but we prefer to use
 create and manage a Python virtual environment specific to this
 project.
 
-If you already have `pyenv` and `pyenv-virtualenv` configured you can
-take advantage of the `setup-env` tool in this repo to automate the
-entire environment configuration process.
+The `setup-env` tool in this repository is our recommended method
+for automating the entire environment configuration process. The
+dependencies required to run this tool are
+[`gnu-getopt`](https://manned.org/getopt.1), `pyenv`, and
+`pyenv-virtualenv`. If these tools are already configured on
+your system, you can simply run the following command.
 
 ```console
 ./setup-env
@@ -57,13 +60,14 @@ entire environment configuration process.
 Otherwise, follow the steps below to manually configure your
 environment.
 
-#### Installing and using `pyenv` and `pyenv-virtualenv` ####
+#### Installing and using `gnu-getopt`, `pyenv`, and `pyenv-virtualenv` ####
 
 On the Mac, we recommend installing [brew](https://brew.sh/).  Then
-installation is as simple as `brew install pyenv pyenv-virtualenv` and
+installation is as simple as `brew install gnu-getopt pyenv pyenv-virtualenv` and
 adding this to your profile:
 
 ```bash
+export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init --path)"
@@ -78,6 +82,8 @@ install the necessary tools. Before running this ensure that you have
 installed the prerequisites for your platform according to the
 [`pyenv` wiki
 page](https://github.com/pyenv/pyenv/wiki/common-build-problems).
+`Gnu-getopt` is generally included in the core utilities of most
+Linux distributions.
 
 On WSL you should treat your platform as whatever Linux distribution
 you've chosen to install.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ adding this to your profile:
 
 ```bash
 # GNU getopt must be explicitly added to the path since it is
-# keg-only
+# keg-only (https://docs.brew.sh/FAQ#what-does-keg-only-mean)
 export PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
 
 # Setup pyenv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,10 @@ project.
 The `setup-env` tool in this repository is our recommended method
 for automating the entire environment configuration process. The
 dependencies required to run this tool are
-[`gnu-getopt`](https://manned.org/getopt.1), `pyenv`, and
-`pyenv-virtualenv`. If these tools are already configured on
-your system, you can simply run the following command.
+[GNU `getopt`](https://github.com/util-linux/util-linux/blob/master/misc-utils/getopt.1.adoc),
+[`pyenv`](https://github.com/pyenv/pyenv), and [`pyenv-virtualenv`](https://github.com/pyenv/pyenv-virtualenv).
+If these tools are already configured on your system, you can simply run the
+following command:
 
 ```console
 ./setup-env
@@ -60,7 +61,7 @@ your system, you can simply run the following command.
 Otherwise, follow the steps below to manually configure your
 environment.
 
-#### Installing and using `gnu-getopt`, `pyenv`, and `pyenv-virtualenv` ####
+#### Installing and using GNU `getopt`, `pyenv`, and `pyenv-virtualenv` ####
 
 On the Mac, we recommend installing [brew](https://brew.sh/).  Then
 installation is as simple as `brew install gnu-getopt pyenv pyenv-virtualenv` and
@@ -81,8 +82,8 @@ install the necessary tools. Before running this ensure that you have
 installed the prerequisites for your platform according to the
 [`pyenv` wiki
 page](https://github.com/pyenv/pyenv/wiki/common-build-problems).
-`gnu-getopt` is generally included in the core utilities of most
-Linux distributions.
+GNU `getopt` is included in most Linux distributions as part of the
+[`util-linux`](https://github.com/util-linux/util-linux) package.
 
 On WSL you should treat your platform as whatever Linux distribution
 you've chosen to install.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ environment.
 
 #### Installing and using GNU `getopt`, `pyenv`, and `pyenv-virtualenv` ####
 
-On the Mac, we recommend installing [brew](https://brew.sh/).  Then
+On macOS, we recommend installing [brew](https://brew.sh/).  Then
 installation is as simple as `brew install gnu-getopt pyenv pyenv-virtualenv` and
 adding this to your profile:
 
@@ -80,7 +80,7 @@ eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 ```
 
-For Linux, Windows Subsystem for Linux (WSL), or on the Mac (if you
+For Linux, Windows Subsystem for Linux (WSL), or on macOS (if you
 don't want to use `brew`) you can use
 [pyenv/pyenv-installer](https://github.com/pyenv/pyenv-installer) to
 install the necessary tools. Before running this ensure that you have

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ project.
 
 We recommend using the `setup-env` script located in this repository,
 as it automates the entire environment configuration process. The
-dependencies required to run this tool are
+dependencies required to run this script are
 [GNU `getopt`](https://github.com/util-linux/util-linux/blob/master/misc-utils/getopt.1.adoc),
 [`pyenv`](https://github.com/pyenv/pyenv), and [`pyenv-virtualenv`](https://github.com/pyenv/pyenv-virtualenv).
 If these tools are already configured on your system, you can simply run the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ adding this to your profile:
 
 ```bash
 export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/bin:/usr/local/opt/gnu-getopt/bin:$PATH"
+export PATH="$PYENV_ROOT/bin:$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
 eval "$(pyenv init --path)"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ There are a few ways to do this, but we prefer to use
 create and manage a Python virtual environment specific to this
 project.
 
-We recommend using the `setup-env` tool located in this repository,
+We recommend using the `setup-env` script located in this repository,
 as it automates the entire environment configuration process. The
 dependencies required to run this tool are
 [GNU `getopt`](https://github.com/util-linux/util-linux/blob/master/misc-utils/getopt.1.adoc),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,8 @@ adding this to your profile:
 
 ```bash
 export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/bin:$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
+export PATH="$PYENV_ROOT/bin:$PATH"
+export PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
 eval "$(pyenv init --path)"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,8 @@ installation is as simple as `brew install gnu-getopt pyenv pyenv-virtualenv` an
 adding this to your profile:
 
 ```bash
-# Enable GNU getopt since it is keg-only
+# GNU getopt must be explicitly added to the path since it is
+# keg-only
 export PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
 
 # Setup pyenv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,9 +67,8 @@ installation is as simple as `brew install gnu-getopt pyenv pyenv-virtualenv` an
 adding this to your profile:
 
 ```bash
-export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
 export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/bin:$PATH"
+export PATH="$PYENV_ROOT/bin:/usr/local/opt/gnu-getopt/bin:$PATH"
 eval "$(pyenv init --path)"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ There are a few ways to do this, but we prefer to use
 create and manage a Python virtual environment specific to this
 project.
 
-The `setup-env` tool in this repository is our recommended method
-for automating the entire environment configuration process. The
+We recommend using the `setup-env` tool located in this repository,
+as it automates the entire environment configuration process. The
 dependencies required to run this tool are
 [GNU `getopt`](https://github.com/util-linux/util-linux/blob/master/misc-utils/getopt.1.adoc),
 [`pyenv`](https://github.com/pyenv/pyenv), and [`pyenv-virtualenv`](https://github.com/pyenv/pyenv-virtualenv).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ install the necessary tools. Before running this ensure that you have
 installed the prerequisites for your platform according to the
 [`pyenv` wiki
 page](https://github.com/pyenv/pyenv/wiki/common-build-problems).
-`Gnu-getopt` is generally included in the core utilities of most
+`gnu-getopt` is generally included in the core utilities of most
 Linux distributions.
 
 On WSL you should treat your platform as whatever Linux distribution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 ```
 
-For Linux, Windows Subsystem for Linux (WSL), or on macOS (if you
+For Linux, Windows Subsystem for Linux (WSL), or macOS (if you
 don't want to use `brew`) you can use
 [pyenv/pyenv-installer](https://github.com/pyenv/pyenv-installer) to
 install the necessary tools. Before running this ensure that you have

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,12 @@ installation is as simple as `brew install gnu-getopt pyenv pyenv-virtualenv` an
 adding this to your profile:
 
 ```bash
+# Enable GNU getopt since it is keg-only
+export PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
+
+# Setup pyenv
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
-export PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
 eval "$(pyenv init --path)"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"

--- a/setup-env
+++ b/setup-env
@@ -19,8 +19,7 @@ It does the following:
   - Configures git upstream remote "lineage" repositories.
 
 Usage:
-  setup-env (-n | --name) [virt_env_name]
-  setup-env (-v | --version) [python_version]
+  setup-env (-n | --name) [virt_env_name] (-v | --version) [python_version]
   setup-env (-h | --help)
 
 Options:

--- a/setup-env
+++ b/setup-env
@@ -41,9 +41,6 @@ PARAMS=""
 PYTHON_VERSION=""
 LIST_VERSIONS=0
 
-# Temp file that is used to search through available installed Python versions
-TMPFILE=/tmp/versions.$$
-
 # Parse command line arguments
 while (("$#")); do
   case "$1" in
@@ -136,9 +133,8 @@ if [ $LIST_VERSIONS -ne 0 ]; then
 fi
 
 # Check if PYTHON_VERSION isn't empty. If it is installed, set it locally.
-pyenv versions --bare --skip-aliases --skip-envs > $TMPFILE
 if [ -n "$PYTHON_VERSION" ]; then
-  if grep --fixed-strings --quiet "$PYTHON_VERSION" $TMPFILE; then
+  if pyenv versions --bare --skip-aliases --skip-envs | grep --fixed-strings "$PYTHON_VERSION" >/dev/null; then
     echo Using Python version "$PYTHON_VERSION"
     pyenv local "$PYTHON_VERSION"
   else

--- a/setup-env
+++ b/setup-env
@@ -25,6 +25,8 @@ Options:
   -h --help           Show this message.
   -i --install-hooks  Install hook environments for all environments in the
                       pre-commit config file.
+  -v --version        Specify the Python version for the virtual environment.
+  -l --list-versions  List available Python versions and select interactively.
 
 END_OF_LINE
 )
@@ -34,6 +36,13 @@ FORCE=0
 
 # Positional parameters
 PARAMS=""
+
+# Flags to allow a user to specify which version of Python they want to use
+PYTHON_VERSION=""
+LIST_VERSIONS=0
+
+# Temp file that is used to search through available installed Python versions
+TMPFILE=/tmp/versions.$$
 
 # Parse command line arguments
 while (("$#")); do
@@ -48,6 +57,14 @@ while (("$#")); do
       ;;
     -i | --install-hooks)
       INSTALL_HOOKS=1
+      shift
+      ;;
+    -v | --version)
+      PYTHON_VERSION=$2
+      shift 2
+      ;;
+    -l | --list-versions)
+      LIST_VERSIONS=1
       shift
       ;;
     -*) # unsupported flags
@@ -111,6 +128,25 @@ else
 fi
 set -o nounset
 
+# List Python versions and select one interactively
+if [ $LIST_VERSIONS -ne 0 ]; then
+  echo Available Python versions:
+  pyenv versions --bare --skip-aliases --skip-envs
+  read -p -r "Enter the desired Python version: " PYTHON_VERSION
+fi
+
+# Check if PYTHON_VERSION isn't empty. If it is installed, set it locally.
+pyenv versions --bare --skip-aliases --skip-envs > $TMPFILE
+if [ -n "$PYTHON_VERSION" ]; then
+  if grep --fixed-strings --quiet "$PYTHON_VERSION" $TMPFILE; then
+    echo Using Python version "$PYTHON_VERSION"
+    pyenv local "$PYTHON_VERSION"
+  else
+    echo Error: Python version "$PYTHON_VERSION" is not installed.
+  fi
+  exit 1
+fi
+
 # Remove any lingering local configuration.
 if [ $FORCE -ne 0 ]; then
   rm -f .python-version
@@ -130,10 +166,10 @@ fi
 # Create a new virtual environment for this project
 if ! pyenv virtualenv "${env_name}"; then
   cat << END_OF_LINE
-  An existing virtual environment named $env_name was found.  Either delete this
-  environment yourself or re-run with --force option to have it deleted.
+    An existing virtual environment named $env_name was found.  Either delete this
+    environment yourself or re-run with --force option to have it deleted.
 
-  pyenv virtualenv-delete ${env_name}
+    pyenv virtualenv-delete ${env_name}
 
 END_OF_LINE
   exit 1

--- a/setup-env
+++ b/setup-env
@@ -63,7 +63,7 @@ if [[ $(getopt --version 2> /dev/null) != *"getopt from util-linux"* ]]; then
   is as simple as `brew install gnu-getopt` and adding this to your
   profile:
 
-  export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+  export PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
 
 END_OF_LINE
   exit 1

--- a/setup-env
+++ b/setup-env
@@ -165,7 +165,7 @@ while true; do
       break
       ;;
     *)
-      # Unreachable due to gnu-getopt handling all options
+      # Unreachable due to GNU getopt handling all options
       echo "Programming error"
       exit 64
       ;;

--- a/setup-env
+++ b/setup-env
@@ -34,7 +34,7 @@ Options:
 END_OF_LINE
 )
 
-# Display installed python versions
+# Display pyenv's installed Python versions
 python_versions() {
   pyenv versions --bare --skip-aliases --skip-envs
 }

--- a/setup-env
+++ b/setup-env
@@ -17,16 +17,18 @@ It does the following:
   - Configures git upstream remote "lineage" repositories.
 
 Usage:
-  setup-env [options] [virt_env_name]
-  setup-env (-h | --help)
+  setup-env [-n] [virt_env_name]
+  setup-env [-v] [python_version]
+  setup-env (-h)
 
 Options:
-  -f --force          Delete virtual enviroment if it already exists.
-  -h --help           Show this message.
-  -i --install-hooks  Install hook environments for all environments in the
-                      pre-commit config file.
-  -l --list-versions  List available Python versions and select interactively.
-  -v --version        Specify the Python version for the virtual environment.
+  -f      Delete virtual enviroment if it already exists.
+  -h      Show this message.
+  -i      Install hook environments for all environments in the
+          pre-commit config file.
+  -l      List available Python versions and select interactively.
+  -n      Choose the name of the virtual environment.
+  -v      Specify the Python version for the virtual environment.
 
 END_OF_LINE
 )
@@ -49,9 +51,9 @@ OPTS="fhilv:n:"
 # Parse options using BSD getopt
 OPTIND=1
 
-# Display installed python versions 
+# Display installed python versions
 python_versions() {
-    pyenv versions --bare --skip-aliases --skip-envs
+  pyenv versions --bare --skip-aliases --skip-envs
 }
 
 # Parse command line arguments
@@ -82,21 +84,21 @@ while getopts :$OPTS opt; do
         exit 1
       fi
       ;;
-    \:)
-      echo Error: Option -$OPTARG requires an argument.
+    :)
+      echo -e "Error: Option -$OPTARG requires an argument. \n"
       echo "$USAGE"
       exit 1
       ;;
     \?)
-      echo -e "Invalid option please look through usage: \n" 
+      echo -e "Invalid option please look through usage: \n"
       echo "$USAGE"
       exit 1
       ;;
-    
+
   esac
 done
 
-shift $((OPTIND-1))
+shift $((OPTIND - 1))
 
 # set positional arguments in their proper place
 eval set -- "$PARAMS"
@@ -155,17 +157,6 @@ if [ $LIST_VERSIONS -ne 0 ]; then
   read -r -p "Enter the desired Python version: " PYTHON_VERSION
 fi
 
-# Check if PYTHON_VERSION is defined. If it is defined then check that
-# it is a valid value.
-if [ -n "${PYTHON_VERSION+x}" ]; then
-  if pyenv versions --bare --skip-aliases --skip-envs | grep --fixed-strings "$PYTHON_VERSION" > /dev/null; then
-    echo Using Python version "$PYTHON_VERSION"
-  else
-    echo Error: Python version "$PYTHON_VERSION" is not installed.
-    exit 1
-  fi
-fi
-
 # Remove any lingering local configuration.
 if [ $FORCE -ne 0 ]; then
   rm -f .python-version
@@ -173,7 +164,7 @@ if [ $FORCE -ne 0 ]; then
 elif [[ -f .python-version ]]; then
   cat << 'END_OF_LINE'
   An existing .python-version file was found.  Either remove this file yourself
-  or re-run with --force option to have it deleted along with the associated
+  or re-run with -f (force) option to have it deleted along with the associated
   virtual environment.
 
   rm .python-version
@@ -194,7 +185,7 @@ fi
 if ! pyenv virtualenv ${PYTHON_VERSION:=} "${env_name}"; then
   cat << END_OF_LINE
   An existing virtual environment named $env_name was found.  Either delete this
-  environment yourself or re-run with --force option to have it deleted.
+  environment yourself or re-run with -f (force) option to have it deleted.
 
   pyenv virtualenv-delete ${env_name}
 

--- a/setup-env
+++ b/setup-env
@@ -9,6 +9,8 @@ USAGE=$(
 Configure a development environment for this repository.
 
 It does the following:
+  - Allows user to specify Python version.
+  - Allows user to choose name for their virtual environment.
   - Verifies pyenv and pyenv-virtualenv are installed.
   - Creates a Python virtual environment.
   - Configures the activation of the virtual enviroment for the repo directory.
@@ -17,18 +19,18 @@ It does the following:
   - Configures git upstream remote "lineage" repositories.
 
 Usage:
-  setup-env [-n] [virt_env_name]
-  setup-env [-v] [python_version]
-  setup-env (-h)
+  setup-env (-n | --name) [virt_env_name]
+  setup-env (-v | --version) [python_version]
+  setup-env (-h | --help)
 
 Options:
-  -f      Delete virtual enviroment if it already exists.
-  -h      Show this message.
-  -i      Install hook environments for all environments in the
-          pre-commit config file.
-  -l      List available Python versions and select interactively.
-  -n      Choose the name of the virtual environment.
-  -v      Specify the Python version for the virtual environment.
+  -f | --force             Delete virtual enviroment if it already exists.
+  -h | --help              Show this message.
+  -i | --install-hooks     Install hook environments for all environments in the
+                           pre-commit config file.
+  -l | --list-versions     List available Python versions and select interactively.
+  -n | --name              Choose the name of the virtual environment.
+  -v | --version           Specify the Python version for the virtual environment.
 
 END_OF_LINE
 )

--- a/setup-env
+++ b/setup-env
@@ -180,10 +180,12 @@ else
   env_name=${PWD##*/}
 fi
 
-# List Python versions and select one interactively
+# List Python versions and select one interactively.
 if [ $LIST_VERSIONS -ne 0 ]; then
   echo Available Python versions:
   python_versions
+  # Read the user's desired Python version.
+  # -r: treat backslashes as literal, -p: display prompt before input.
   read -r -p "Enter the desired Python version: " PYTHON_VERSION
   # Check the Python versions being passed in.
   if [ -n "${PYTHON_VERSION+x}" ]; then

--- a/setup-env
+++ b/setup-env
@@ -54,7 +54,9 @@ LONGOPTS="force,help,install-hooks,list-versions,python-version:,venv-name:"
 # Define short options for getopt
 SHORTOPTS="fhilp:v:"
 
-# Check if GNU getopt is available
+# Check for GNU getopt by matching a specific pattern ("getopt from util-linux")
+# in its version output. This approach presumes the output format remains stable.
+# Be aware that format changes could invalidate this check.
 if [[ $(getopt --version 2> /dev/null) != *"getopt from util-linux"* ]]; then
   cat << 'END_OF_LINE'
 

--- a/setup-env
+++ b/setup-env
@@ -34,8 +34,20 @@ END_OF_LINE
 # Flag to force deletion and creation of virtual environment
 FORCE=0
 
+# Initialize the all other flags
+INSTALL_HOOKS=0
+LIST_VERSIONS=0
+PYTHON_VERSION=""
+VENV_NAME=""
+
 # Positional parameters
 PARAMS=""
+
+# Define short options for getopt
+OPTS="fhilv:n:"
+
+# Parse options using BSD getopt
+OPTIND=1
 
 # A flag to allow a user to specify which version of Python they want
 # to use.

--- a/setup-env
+++ b/setup-env
@@ -162,10 +162,10 @@ fi
 # Create a new virtual environment for this project
 if ! pyenv virtualenv "${env_name}"; then
   cat << END_OF_LINE
-    An existing virtual environment named $env_name was found.  Either delete this
-    environment yourself or re-run with --force option to have it deleted.
+  An existing virtual environment named $env_name was found.  Either delete this
+  environment yourself or re-run with --force option to have it deleted.
 
-    pyenv virtualenv-delete ${env_name}
+  pyenv virtualenv-delete ${env_name}
 
 END_OF_LINE
   exit 1

--- a/setup-env
+++ b/setup-env
@@ -59,7 +59,7 @@ if [[ $(getopt --version 2> /dev/null) != *"getopt from util-linux"* ]]; then
   cat << 'END_OF_LINE'
 
   GNU getopt is not detected and is a dependency to run this script.
-  On the Mac, we recommend installing brew, https://brew.sh/.  Then installation
+  On the Mac, we recommend installing brew (https://brew.sh/).  Then installation
   is as simple as `brew install gnu-getopt` and adding this to your
   profile:
 

--- a/setup-env
+++ b/setup-env
@@ -73,6 +73,8 @@ if [[ $(getopt --version 2> /dev/null) != *"getopt from util-linux"* ]]; then
 
   export PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
 
+  This will enable GNU getopt since it is keg-only.
+
 END_OF_LINE
   exit 1
 fi

--- a/setup-env
+++ b/setup-env
@@ -166,7 +166,6 @@ END_OF_LINE
   exit 1
 fi
 
-set +o nounset
 # Determine the virtual environment name
 if [ -n "$VENV_NAME" ]; then
   # Use the user-provided environment name
@@ -175,7 +174,6 @@ else
   # Set the environment name to the last part of the working directory.
   env_name=${PWD##*/}
 fi
-set -o nounset
 
 # List Python versions and select one interactively
 if [ $LIST_VERSIONS -ne 0 ]; then

--- a/setup-env
+++ b/setup-env
@@ -129,12 +129,12 @@ set -o nounset
 if [ $LIST_VERSIONS -ne 0 ]; then
   echo Available Python versions:
   pyenv versions --bare --skip-aliases --skip-envs
-  read -p -r "Enter the desired Python version: " PYTHON_VERSION
+  read -r -p "Enter the desired Python version: " PYTHON_VERSION
 fi
 
 # Check if PYTHON_VERSION isn't empty. If it is installed, set it locally.
 if [ -n "$PYTHON_VERSION" ]; then
-  if pyenv versions --bare --skip-aliases --skip-envs | grep --fixed-strings "$PYTHON_VERSION" >/dev/null; then
+  if pyenv versions --bare --skip-aliases --skip-envs | grep --fixed-strings "$PYTHON_VERSION" > /dev/null; then
     echo Using Python version "$PYTHON_VERSION"
     pyenv local "$PYTHON_VERSION"
   else

--- a/setup-env
+++ b/setup-env
@@ -165,8 +165,9 @@ while true; do
       break
       ;;
     *)
+      # Unreachable due to gnu-getopt handling all options
       echo "Programming error"
-      exit 3
+      exit 64
       ;;
   esac
 done

--- a/setup-env
+++ b/setup-env
@@ -35,6 +35,11 @@ Options:
 END_OF_LINE
 )
 
+# Display installed python versions
+python_versions() {
+  pyenv versions --bare --skip-aliases --skip-envs
+}
+
 # Flag to force deletion and creation of virtual environment
 FORCE=0
 
@@ -44,66 +49,81 @@ LIST_VERSIONS=0
 PYTHON_VERSION=""
 VENV_NAME=""
 
-# Positional parameters
-PARAMS=""
+# Define long options
+LONGOPTS="force,help,install-hooks,list-versions,name:,version:"
 
 # Define short options for getopt
-OPTS="fhilv:n:"
+SHORTOPTS="fhiln:v:"
 
-# Parse options using BSD getopt
-OPTIND=1
+# Check if GNU getopt is available
+if [[ $(getopt --version 2> /dev/null) != *"getopt from util-linux"* ]]; then
+  cat << 'END_OF_LINE'
 
-# Display installed python versions
-python_versions() {
-  pyenv versions --bare --skip-aliases --skip-envs
-}
+  Gnu-getopt is not detected and is a dependency to run this script.
+  On the Mac, we recommend installing brew, https://brew.sh/.  Then installation
+  is as simple as `brew install gnu-getopt` and adding this to your
+  profile:
 
-# Parse command line arguments
-while getopts :$OPTS opt; do
-  case $opt in
-    f)
+  export PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+
+END_OF_LINE
+  exit 1
+fi
+
+# Use GNU getopt to parse options
+if ! PARSED=$(getopt --options $SHORTOPTS --longoptions $LONGOPTS --name "$0" -- "$@"); then
+  echo "Error parsing options"
+  exit 2
+fi
+eval set -- "$PARSED"
+
+while true; do
+  case "$1" in
+    -f | --force)
       FORCE=1
+      shift
       ;;
-    h)
+    -h | --help)
       echo "$USAGE"
       exit 0
       ;;
-    i)
+    -i | --install-hooks)
       INSTALL_HOOKS=1
+      shift
       ;;
-    l)
+    -l | --list-versions)
       LIST_VERSIONS=1
+      shift
       ;;
-    n)
-      VENV_NAME="$OPTARG"
+    -n | --name)
+      VENV_NAME="$2"
+      shift 2
       ;;
-    v)
-      PYTHON_VERSION="$OPTARG"
-      # Check if Python version is valid and installed
-      if ! python_versions | grep --fixed-strings "$PYTHON_VERSION" > /dev/null; then
-        echo "Error: Python version $PYTHON_VERSION is not installed. Versions available:"
-        python_versions
-        exit 1
+    -v | --version)
+      PYTHON_VERSION="$2"
+      shift 2
+      # Check the Python versions being passed in.
+      if [ -n "${PYTHON_VERSION+x}" ]; then
+        if python_versions | grep -E "^${PYTHON_VERSION}$" > /dev/null; then
+          echo Using Python version "$PYTHON_VERSION"
+        else
+          echo Error: Python version "$PYTHON_VERSION" is not installed.
+          echo Installed Python versions are:
+          python_versions
+          exit 1
+        fi
       fi
       ;;
-    :)
-      echo -e "Error: Option -$OPTARG requires an argument. \n"
-      echo "$USAGE"
-      exit 1
+    --)
+      shift
+      break
       ;;
-    \?)
-      echo -e "Invalid option please look through usage: \n"
-      echo "$USAGE"
-      exit 1
+    *)
+      echo "Programming error"
+      exit 3
       ;;
-
   esac
 done
-
-shift $((OPTIND - 1))
-
-# set positional arguments in their proper place
-eval set -- "$PARAMS"
 
 # Check to see if pyenv is installed
 if [ -z "$(command -v pyenv)" ] || { [ -z "$(command -v pyenv-virtualenv)" ] && [ ! -f "$(pyenv root)/plugins/pyenv-virtualenv/bin/pyenv-virtualenv" ]; }; then
@@ -157,6 +177,15 @@ if [ $LIST_VERSIONS -ne 0 ]; then
   echo Available Python versions:
   python_versions
   read -r -p "Enter the desired Python version: " PYTHON_VERSION
+  # Check the Python versions being passed in.
+  if [ -n "${PYTHON_VERSION+x}" ]; then
+    if python_versions | grep -E "^${PYTHON_VERSION}$" > /dev/null; then
+      echo Using Python version "$PYTHON_VERSION"
+    else
+      echo Error: Python version "$PYTHON_VERSION" is not installed.
+      exit 1
+    fi
+  fi
 fi
 
 # Remove any lingering local configuration.

--- a/setup-env
+++ b/setup-env
@@ -19,7 +19,7 @@ It does the following:
   - Configures git upstream remote "lineage" repositories.
 
 Usage:
-  setup-env (-n | --name) [virtual_env_name] (-v | --version) [python_version]
+  setup-env [--venv-name virtual_env_name] [--python-version python_version]
   setup-env (-h | --help)
 
 Options:
@@ -28,8 +28,8 @@ Options:
   -i | --install-hooks     Install hook environments for all environments in the
                            pre-commit config file.
   -l | --list-versions     List available Python versions and select interactively.
-  -n | --name              Specify the name of the virtual environment.
-  -v | --version           Specify the Python version for the virtual environment.
+  -v | --venv-name              Specify the name of the virtual environment.
+  -p | --python-version           Specify the Python version for the virtual environment.
 
 END_OF_LINE
 )
@@ -49,10 +49,10 @@ PYTHON_VERSION=""
 VENV_NAME=""
 
 # Define long options
-LONGOPTS="force,help,install-hooks,list-versions,name:,version:"
+LONGOPTS="force,help,install-hooks,list-versions,python-version:,venv-name:"
 
 # Define short options for getopt
-SHORTOPTS="fhiln:v:"
+SHORTOPTS="fhilp:v:"
 
 # Check if GNU getopt is available
 if [[ $(getopt --version 2> /dev/null) != *"getopt from util-linux"* ]]; then
@@ -94,11 +94,7 @@ while true; do
       LIST_VERSIONS=1
       shift
       ;;
-    -n | --name)
-      VENV_NAME="$2"
-      shift 2
-      ;;
-    -v | --version)
+    -p | --python-version)
       PYTHON_VERSION="$2"
       shift 2
       # Check the Python versions being passed in.
@@ -112,6 +108,10 @@ while true; do
           exit 1
         fi
       fi
+      ;;
+    -v | --venv-name)
+      VENV_NAME="$2"
+      shift 2
       ;;
     --)
       shift

--- a/setup-env
+++ b/setup-env
@@ -136,7 +136,6 @@ fi
 if [ -n "$PYTHON_VERSION" ]; then
   if pyenv versions --bare --skip-aliases --skip-envs | grep --fixed-strings "$PYTHON_VERSION" > /dev/null; then
     echo Using Python version "$PYTHON_VERSION"
-    pyenv local "$PYTHON_VERSION"
   else
     echo Error: Python version "$PYTHON_VERSION" is not installed.
     exit 1

--- a/setup-env
+++ b/setup-env
@@ -19,7 +19,7 @@ It does the following:
   - Configures git remotes for upstream "lineage" repositories.
 
 Usage:
-  setup-env [--venv-name virtual_env_name] [--python-version python_version]
+  setup-env [--venv-name venv_name] [--python-version python_version]
   setup-env (-h | --help)
 
 Options:
@@ -67,7 +67,7 @@ if [[ $(getopt --version 2> /dev/null) != *"getopt from util-linux"* ]]; then
   as a system might have a non-GNU version of getopt installed by default,
   which could lead to unexpected behavior.
 
-  On the Mac, we recommend installing brew (https://brew.sh/).  Then installation
+  On macOS, we recommend installing brew (https://brew.sh/).  Then installation
   is as simple as `brew install gnu-getopt` and adding this to your
   profile:
 
@@ -86,7 +86,7 @@ if [ -z "$(command -v pyenv)" ] || { [ -z "$(command -v pyenv-virtualenv)" ] && 
   if [[ "$OSTYPE" == "darwin"* ]]; then
     cat << 'END_OF_LINE'
 
-  On the Mac, we recommend installing brew, https://brew.sh/.  Then installation
+  On macOS, we recommend installing brew, https://brew.sh/.  Then installation
   is as simple as `brew install pyenv pyenv-virtualenv` and adding this to your
   profile:
 
@@ -97,7 +97,7 @@ END_OF_LINE
 
   fi
   cat << 'END_OF_LINE'
-  For Linux, Windows Subsystem for Linux (WSL), or on the Mac (if you don't want
+  For Linux, Windows Subsystem for Linux (WSL), or on mac OS (if you don't want
   to use "brew") you can use https://github.com/pyenv/pyenv-installer to install
   the necessary tools. Before running this ensure that you have installed the
   prerequisites for your platform according to the pyenv wiki page,

--- a/setup-env
+++ b/setup-env
@@ -217,7 +217,7 @@ fi
 
 # Create a new virtual environment for this project
 #
-# If $PYTHON_VERSION is undefined then the system Python will be used.
+# If $PYTHON_VERSION is undefined then the global version of Python will be used.
 #
 # We can't quote ${PYTHON_VERSION:=} below since if the variable is
 # undefined then we want nothing to appear; this is the reason for the

--- a/setup-env
+++ b/setup-env
@@ -80,6 +80,42 @@ END_OF_LINE
   exit 1
 fi
 
+# Check to see if pyenv is installed
+if [ -z "$(command -v pyenv)" ] || { [ -z "$(command -v pyenv-virtualenv)" ] && [ ! -f "$(pyenv root)/plugins/pyenv-virtualenv/bin/pyenv-virtualenv" ]; }; then
+  echo "pyenv and pyenv-virtualenv are required."
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    cat << 'END_OF_LINE'
+
+  On the Mac, we recommend installing brew, https://brew.sh/.  Then installation
+  is as simple as `brew install pyenv pyenv-virtualenv` and adding this to your
+  profile:
+
+  eval "$(pyenv init -)"
+  eval "$(pyenv virtualenv-init -)"
+
+END_OF_LINE
+
+  fi
+  cat << 'END_OF_LINE'
+  For Linux, Windows Subsystem for Linux (WSL), or on the Mac (if you don't want
+  to use "brew") you can use https://github.com/pyenv/pyenv-installer to install
+  the necessary tools. Before running this ensure that you have installed the
+  prerequisites for your platform according to the pyenv wiki page,
+  https://github.com/pyenv/pyenv/wiki/common-build-problems.
+
+  On WSL you should treat your platform as whatever Linux distribution you've
+  chosen to install.
+
+  Once you have installed "pyenv" you will need to add the following lines to
+  your ".bashrc":
+
+  export PATH="$PATH:$HOME/.pyenv/bin"
+  eval "$(pyenv init -)"
+  eval "$(pyenv virtualenv-init -)"
+END_OF_LINE
+  exit 1
+fi
+
 # Use GNU getopt to parse options
 if ! PARSED=$(getopt --options $SHORTOPTS --longoptions $LONGOPTS --name "$0" -- "$@"); then
   echo "Error parsing options"
@@ -134,42 +170,6 @@ while true; do
       ;;
   esac
 done
-
-# Check to see if pyenv is installed
-if [ -z "$(command -v pyenv)" ] || { [ -z "$(command -v pyenv-virtualenv)" ] && [ ! -f "$(pyenv root)/plugins/pyenv-virtualenv/bin/pyenv-virtualenv" ]; }; then
-  echo "pyenv and pyenv-virtualenv are required."
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    cat << 'END_OF_LINE'
-
-  On the Mac, we recommend installing brew, https://brew.sh/.  Then installation
-  is as simple as `brew install pyenv pyenv-virtualenv` and adding this to your
-  profile:
-
-  eval "$(pyenv init -)"
-  eval "$(pyenv virtualenv-init -)"
-
-END_OF_LINE
-
-  fi
-  cat << 'END_OF_LINE'
-  For Linux, Windows Subsystem for Linux (WSL), or on the Mac (if you don't want
-  to use "brew") you can use https://github.com/pyenv/pyenv-installer to install
-  the necessary tools. Before running this ensure that you have installed the
-  prerequisites for your platform according to the pyenv wiki page,
-  https://github.com/pyenv/pyenv/wiki/common-build-problems.
-
-  On WSL you should treat your platform as whatever Linux distribution you've
-  chosen to install.
-
-  Once you have installed "pyenv" you will need to add the following lines to
-  your ".bashrc":
-
-  export PATH="$PATH:$HOME/.pyenv/bin"
-  eval "$(pyenv init -)"
-  eval "$(pyenv virtualenv-init -)"
-END_OF_LINE
-  exit 1
-fi
 
 # Determine the virtual environment name
 if [ -n "$VENV_NAME" ]; then

--- a/setup-env
+++ b/setup-env
@@ -9,10 +9,10 @@ USAGE=$(
 Configure a development environment for this repository.
 
 It does the following:
-  - Allows user to specify Python version.
-  - Allows user to choose name for their virtual environment.
+  - Allows the user to specify the Python version to use for the virtual environment.
+  - Allows the user to specify a name for the virtual environment.
   - Verifies pyenv and pyenv-virtualenv are installed.
-  - Creates a Python virtual environment.
+  - Creates the Python virtual environment.
   - Configures the activation of the virtual enviroment for the repo directory.
   - Installs the requirements needed for development.
   - Installs git pre-commit hooks.
@@ -29,7 +29,7 @@ Options:
   -i | --install-hooks     Install hook environments for all environments in the
                            pre-commit config file.
   -l | --list-versions     List available Python versions and select interactively.
-  -n | --name              Choose the name of the virtual environment.
+  -n | --name              Specify the name of the virtual environment.
   -v | --version           Specify the Python version for the virtual environment.
 
 END_OF_LINE
@@ -195,7 +195,7 @@ if [ $FORCE -ne 0 ]; then
 elif [[ -f .python-version ]]; then
   cat << 'END_OF_LINE'
   An existing .python-version file was found.  Either remove this file yourself
-  or re-run with -f (force) option to have it deleted along with the associated
+  or re-run with the --force option to have it deleted along with the associated
   virtual environment.
 
   rm .python-version
@@ -216,7 +216,7 @@ fi
 if ! pyenv virtualenv ${PYTHON_VERSION:=} "${env_name}"; then
   cat << END_OF_LINE
   An existing virtual environment named $env_name was found.  Either delete this
-  environment yourself or re-run with -f (force) option to have it deleted.
+  environment yourself or re-run with the --force option to have it deleted.
 
   pyenv virtualenv-delete ${env_name}
 

--- a/setup-env
+++ b/setup-env
@@ -16,7 +16,7 @@ It does the following:
   - Configures the activation of the virtual enviroment for the repo directory.
   - Installs the requirements needed for development.
   - Installs git pre-commit hooks.
-  - Configures git upstream remote "lineage" repositories.
+  - Configures git remotes for upstream "lineage" repositories.
 
 Usage:
   setup-env [--venv-name virtual_env_name] [--python-version python_version]

--- a/setup-env
+++ b/setup-env
@@ -25,8 +25,8 @@ Options:
   -h --help           Show this message.
   -i --install-hooks  Install hook environments for all environments in the
                       pre-commit config file.
-  -v --version        Specify the Python version for the virtual environment.
   -l --list-versions  List available Python versions and select interactively.
+  -v --version        Specify the Python version for the virtual environment.
 
 END_OF_LINE
 )
@@ -56,13 +56,13 @@ while (("$#")); do
       INSTALL_HOOKS=1
       shift
       ;;
-    -v | --version)
-      PYTHON_VERSION=$2
-      shift 2
-      ;;
     -l | --list-versions)
       LIST_VERSIONS=1
       shift
+      ;;
+    -v | --version)
+      PYTHON_VERSION=$2
+      shift 2
       ;;
     -*) # unsupported flags
       echo "Error: Unsupported flag $1" >&2

--- a/setup-env
+++ b/setup-env
@@ -49,10 +49,6 @@ OPTS="fhilv:n:"
 # Parse options using BSD getopt
 OPTIND=1
 
-# A flag to allow a user to specify which version of Python they want
-# to use.
-LIST_VERSIONS=0
-
 # Parse command line arguments
 while (("$#")); do
   case "$1" in

--- a/setup-env
+++ b/setup-env
@@ -139,8 +139,8 @@ if [ -n "$PYTHON_VERSION" ]; then
     pyenv local "$PYTHON_VERSION"
   else
     echo Error: Python version "$PYTHON_VERSION" is not installed.
+    exit 1
   fi
-  exit 1
 fi
 
 # Remove any lingering local configuration.

--- a/setup-env
+++ b/setup-env
@@ -73,7 +73,8 @@ if [[ $(getopt --version 2> /dev/null) != *"getopt from util-linux"* ]]; then
 
   export PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
 
-  This will enable GNU getopt since it is keg-only.
+  GNU getopt must be explicitly added to the PATH since it
+  is keg-only.
 
 END_OF_LINE
   exit 1

--- a/setup-env
+++ b/setup-env
@@ -74,7 +74,7 @@ if [[ $(getopt --version 2> /dev/null) != *"getopt from util-linux"* ]]; then
   export PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
 
   GNU getopt must be explicitly added to the PATH since it
-  is keg-only.
+  is keg-only (https://docs.brew.sh/FAQ#what-does-keg-only-mean).
 
 END_OF_LINE
   exit 1

--- a/setup-env
+++ b/setup-env
@@ -42,7 +42,7 @@ python_versions() {
 # Flag to force deletion and creation of virtual environment
 FORCE=0
 
-# Initialize the all other flags
+# Initialize the other flags
 INSTALL_HOOKS=0
 LIST_VERSIONS=0
 PYTHON_VERSION=""

--- a/setup-env
+++ b/setup-env
@@ -97,7 +97,7 @@ END_OF_LINE
 
   fi
   cat << 'END_OF_LINE'
-  For Linux, Windows Subsystem for Linux (WSL), or on mac OS (if you don't want
+  For Linux, Windows Subsystem for Linux (WSL), or macOS (if you don't want
   to use "brew") you can use https://github.com/pyenv/pyenv-installer to install
   the necessary tools. Before running this ensure that you have installed the
   prerequisites for your platform according to the pyenv wiki page,
@@ -217,7 +217,7 @@ fi
 
 # Create a new virtual environment for this project
 #
-# If $PYTHON_VERSION is undefined then the global version of Python will be used.
+# If $PYTHON_VERSION is undefined then the current pyenv Python version will be used.
 #
 # We can't quote ${PYTHON_VERSION:=} below since if the variable is
 # undefined then we want nothing to appear; this is the reason for the

--- a/setup-env
+++ b/setup-env
@@ -49,39 +49,54 @@ OPTS="fhilv:n:"
 # Parse options using BSD getopt
 OPTIND=1
 
+# Display installed python versions 
+python_versions() {
+    pyenv versions --bare --skip-aliases --skip-envs
+}
+
 # Parse command line arguments
-while (("$#")); do
-  case "$1" in
-    -f | --force)
+while getopts :$OPTS opt; do
+  case $opt in
+    f)
       FORCE=1
-      shift
       ;;
-    -h | --help)
-      echo "${USAGE}"
+    h)
+      echo "$USAGE"
       exit 0
       ;;
-    -i | --install-hooks)
+    i)
       INSTALL_HOOKS=1
-      shift
       ;;
-    -l | --list-versions)
+    l)
       LIST_VERSIONS=1
-      shift
       ;;
-    -v | --version)
-      PYTHON_VERSION=$2
-      shift 2
+    n)
+      VENV_NAME="$OPTARG"
       ;;
-    -*) # unsupported flags
-      echo "Error: Unsupported flag $1" >&2
+    v)
+      PYTHON_VERSION="$OPTARG"
+      # Check if Python version is valid and installed
+      if ! python_versions | grep --fixed-strings "$PYTHON_VERSION" > /dev/null; then
+        echo "Error: Python version $PYTHON_VERSION is not installed. Versions available:"
+        python_versions
+        exit 1
+      fi
+      ;;
+    \:)
+      echo Error: Option -$OPTARG requires an argument.
+      echo "$USAGE"
       exit 1
       ;;
-    *) # preserve positional arguments
-      PARAMS="$PARAMS $1"
-      shift
+    \?)
+      echo -e "Invalid option please look through usage: \n" 
+      echo "$USAGE"
+      exit 1
       ;;
+    
   esac
 done
+
+shift $((OPTIND-1))
 
 # set positional arguments in their proper place
 eval set -- "$PARAMS"
@@ -124,9 +139,9 @@ fi
 
 set +o nounset
 # Determine the virtual environment name
-if [ "$1" ]; then
+if [ -n "$VENV_NAME" ]; then
   # Use the user-provided environment name
-  env_name=$1
+  env_name="$VENV_NAME"
 else
   # Set the environment name to the last part of the working directory.
   env_name=${PWD##*/}
@@ -136,7 +151,7 @@ set -o nounset
 # List Python versions and select one interactively
 if [ $LIST_VERSIONS -ne 0 ]; then
   echo Available Python versions:
-  pyenv versions --bare --skip-aliases --skip-envs
+  python_versions
   read -r -p "Enter the desired Python version: " PYTHON_VERSION
 fi
 

--- a/setup-env
+++ b/setup-env
@@ -27,7 +27,7 @@ Options:
   -h | --help              Show this message.
   -i | --install-hooks     Install hook environments for all environments in the
                            pre-commit config file.
-  -l | --list-versions     List available Python versions and select interactively.
+  -l | --list-versions     List available Python versions and select one interactively.
   -v | --venv-name              Specify the name of the virtual environment.
   -p | --python-version           Specify the Python version for the virtual environment.
 
@@ -63,7 +63,7 @@ if [[ $(getopt --version 2> /dev/null) != *"getopt from util-linux"* ]]; then
   are not supported by the POSIX getopt found in some systems, particularly
   those with a non-GNU version of getopt. This distinction is crucial
   as a system might have a non-GNU version of getopt installed by default,
-  which could lead to unexpected behavior or script failure.
+  which could lead to unexpected behavior.
 
   On the Mac, we recommend installing brew (https://brew.sh/).  Then installation
   is as simple as `brew install gnu-getopt` and adding this to your

--- a/setup-env
+++ b/setup-env
@@ -58,7 +58,7 @@ SHORTOPTS="fhiln:v:"
 if [[ $(getopt --version 2> /dev/null) != *"getopt from util-linux"* ]]; then
   cat << 'END_OF_LINE'
 
-  Gnu-getopt is not detected and is a dependency to run this script.
+  GNU getopt is not detected and is a dependency to run this script.
   On the Mac, we recommend installing brew, https://brew.sh/.  Then installation
   is as simple as `brew install gnu-getopt` and adding this to your
   profile:

--- a/setup-env
+++ b/setup-env
@@ -83,7 +83,7 @@ fi
 # Use GNU getopt to parse options
 if ! PARSED=$(getopt --options $SHORTOPTS --longoptions $LONGOPTS --name "$0" -- "$@"); then
   echo "Error parsing options"
-  exit 2
+  exit 1
 fi
 eval set -- "$PARSED"
 

--- a/setup-env
+++ b/setup-env
@@ -19,7 +19,7 @@ It does the following:
   - Configures git upstream remote "lineage" repositories.
 
 Usage:
-  setup-env (-n | --name) [virt_env_name] (-v | --version) [python_version]
+  setup-env (-n | --name) [virtual_env_name] (-v | --version) [python_version]
   setup-env (-h | --help)
 
 Options:

--- a/setup-env
+++ b/setup-env
@@ -37,8 +37,8 @@ FORCE=0
 # Positional parameters
 PARAMS=""
 
-# Flags to allow a user to specify which version of Python they want to use
-PYTHON_VERSION=""
+# A flag to allow a user to specify which version of Python they want
+# to use.
 LIST_VERSIONS=0
 
 # Parse command line arguments
@@ -132,8 +132,9 @@ if [ $LIST_VERSIONS -ne 0 ]; then
   read -r -p "Enter the desired Python version: " PYTHON_VERSION
 fi
 
-# Check if PYTHON_VERSION isn't empty. If it is installed, set it locally.
-if [ -n "$PYTHON_VERSION" ]; then
+# Check if PYTHON_VERSION is defined. If it is defined then check that
+# it is a valid value.
+if [ -n "${PYTHON_VERSION+x}" ]; then
   if pyenv versions --bare --skip-aliases --skip-envs | grep --fixed-strings "$PYTHON_VERSION" > /dev/null; then
     echo Using Python version "$PYTHON_VERSION"
   else
@@ -159,7 +160,15 @@ END_OF_LINE
 fi
 
 # Create a new virtual environment for this project
-if ! pyenv virtualenv "${env_name}"; then
+#
+# If $PYTHON_VERSION is undefined then the system Python will be used.
+#
+# We can't quote ${PYTHON_VERSION:=} below since if the variable is
+# undefined then we want nothing to appear; this is the reason for the
+# "shellcheck disable" line below.
+#
+# shellcheck disable=SC2086
+if ! pyenv virtualenv ${PYTHON_VERSION:=} "${env_name}"; then
   cat << END_OF_LINE
   An existing virtual environment named $env_name was found.  Either delete this
   environment yourself or re-run with --force option to have it deleted.

--- a/setup-env
+++ b/setup-env
@@ -28,8 +28,8 @@ Options:
   -i | --install-hooks     Install hook environments for all environments in the
                            pre-commit config file.
   -l | --list-versions     List available Python versions and select one interactively.
-  -v | --venv-name              Specify the name of the virtual environment.
-  -p | --python-version           Specify the Python version for the virtual environment.
+  -v | --venv-name         Specify the name of the virtual environment.
+  -p | --python-version    Specify the Python version for the virtual environment.
 
 END_OF_LINE
 )

--- a/setup-env
+++ b/setup-env
@@ -58,7 +58,13 @@ SHORTOPTS="fhilp:v:"
 if [[ $(getopt --version 2> /dev/null) != *"getopt from util-linux"* ]]; then
   cat << 'END_OF_LINE'
 
-  GNU getopt is not detected and is a dependency to run this script.
+  Please note, this script requires GNU getopt due to its enhanced
+  functionality and compatibility with certain script features that
+  are not supported by the POSIX getopt found in some systems, particularly
+  those with a non-GNU version of getopt. This distinction is crucial
+  as a system might have a non-GNU version of getopt installed by default,
+  which could lead to unexpected behavior or script failure.
+
   On the Mac, we recommend installing brew (https://brew.sh/).  Then installation
   is as simple as `brew install gnu-getopt` and adding this to your
   profile:


### PR DESCRIPTION
## 🗣 Description ##

This commit is introducing 3 new flags into the setup-env script. `-l` or`--list-versions` will list available Python versions and allow the user to select a version interactively. The second flag `-v` or `--version` will allow a user to set the version if installed. The third flag `-n` or `--name` will allow a user to specify the name of the virtual environment. (e.g. `./setup-env -v 3.9.6` or `./setup-env --name myVenv`)

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This will resolve [153](https://github.com/cisagov/skeleton-generic/issues/153). The `setup-env` script currently creates the Python virtual environment without specifying a Python version via the command `pyenv virtualenv <venv_name>`. Because no Python version is specified, `pyenv` uses the system Python. This pull request will allow a user to specify which Python version they want to use.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests all passed. I tested the changes locally with different Python versions installed on my system.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
