### PR TITLE
Switch the pre-commit hook used to run `shellcheck`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,10 +115,10 @@ repos:
           - --case-indent
           # Redirect operators are followed by a space
           - --space-redirects
-  - repo: https://github.com/detailyang/pre-commit-shell
-    rev: 1.0.5
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.6
     hooks:
-      - id: shell-lint
+      - id: shellcheck
 
   # Python hooks
   - repo: https://github.com/PyCQA/bandit


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request switches the [pre-commit] hook used to run [shellcheck] from [detailyang/pre-commit-shell] to [shellcheck-py/shellcheck-py].
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The new hook actually bundles the binary releases from [shellcheck] into a Python package that is used for the hook. This will ensure that we are always using the same version of [shellcheck] when linting since individual distributions and the GitHub Actions runners may update at different times..
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I had @dav3r confirm that the hook works on his ARM Mac ([shellcheck] has limited binaries available for macOS).
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[detailyang/pre-commit-shell]: https://github.com/detailyang/pre-commit-shell
[pre-commit]: https://pre-commit.com
[shellcheck]: https://github.com/koalaman/shellcheck
[shellcheck-py/shellcheck-py]: https://github.com/shellcheck-py/shellcheck-py