### PR TITLE
Fix: Build Workflow Runs All Jobs Twice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   merge_group:
     types:
       - checks_requested
+  pull_request:
   push:
   repository_dispatch:
     types:
@@ -31,6 +32,9 @@ jobs:
   diagnostics:
     name: Run diagnostics
     runs-on: ubuntu-latest
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.fork == true
     steps:
       # Note that a duplicate of this step must be added at the top of
       # each job.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
   merge_group:
     types:
       - checks_requested
-  pull_request:
   push:
   repository_dispatch:
     types:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
EDIT: Add conditional to build jobs so they do not run a second time for internal PRs.
~~Remove `on: pull_request` logic from build.yml.~~

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
This logic causes build jobs to run twice on each pull request. This can cause rate limit issues when GitHub Actions is queuing jobs.

The `on: push` logic by itself runs jobs when:
1. A contributor pushes to a branch
2. A contributor creates a pull request
3. A codeowner merges a pull request

The `on: pull_request` logic runs jobs when:

1. A contributor creates a pull request
2. A contributor pushes to a branch connected to a PR

Closes #174 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


## 📷 Screenshots (if appropriate) ##
![image](https://github.com/cisagov/skeleton-generic/assets/106278637/9fe04d65-b8f5-47a7-8e8b-a8adb35c14b9)

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
