### PR TITLE
Add checks for correct semantic version of Python

### DIFF
--- a/setup-env
+++ b/setup-env
@@ -63,7 +63,9 @@ check_python_version() {
   local regex="^($major)\\.($minor)\\.($patch)$prerelease$build\$"
 
   if ! echo "$version" | perl -ne "exit(!/$regex/)"; then
-    echo "Error: The specified Python version $version does not follow the semantic versioning standard."
+    echo "Invalid version of Python: Python follows semantic versioning, " \
+      "so any version string that is not a valid semantic version is an " \
+      "invalid version of Python."
     exit 1
   elif ! python_versions | grep -E "^${version}$" > /dev/null; then
     echo "Error: Python version $version is not installed."

--- a/setup-env
+++ b/setup-env
@@ -39,12 +39,41 @@ python_versions() {
   pyenv versions --bare --skip-aliases --skip-envs
 }
 
-check_semantic_version() {
+check_python_version() {
   local version=$1
-  local regex="^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?\$"
 
-  # Use Perl for regex matching and output true or false
-  echo "$version" | perl -ne "exit(!/$regex/)"
+  # Break down the regex into readable parts major.minor.patch
+  local major="0|[1-9]\\d*"
+  local minor="0|[1-9]\\d*"
+  local patch="0|[1-9]\\d*"
+
+  # Splitting the prerelease part for readability
+  # Start of prerelease
+  local prerelease="(?:-"
+  # Numeric or alphanumeric identifiers
+  local prerelease+="(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+  # Additional dot-separated identifiers
+  local prerelease+="(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*"
+  # End of prerelease, making it optional
+  local prerelease+=")?"
+  # Optional build metadata
+  local build="(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?"
+
+  # Final regex composed of parts
+  local regex="^($major)\\.($minor)\\.($patch)$prerelease$build\$"
+
+  if ! echo "$version" | perl -ne "exit(!/$regex/)"; then
+    echo "Error: The specified Python version $version does not follow the semantic versioning standard."
+    echo "Example of a valid version: 3.8.1, 3.8.1-alpha.1, or 3.8.1+20130313144700"
+    exit 1
+  elif ! python_versions | grep -E "^${version}$" > /dev/null; then
+    echo "Error: Python version $version is not installed."
+    echo "Installed Python versions are:"
+    python_versions
+    exit 1
+  else
+    echo "Using Python version $version"
+  fi
 }
 
 # Flag to force deletion and creation of virtual environment
@@ -152,19 +181,8 @@ while true; do
     -p | --python-version)
       PYTHON_VERSION="$2"
       shift 2
-      # Validate the semantic version format
-      if ! check_semantic_version "$PYTHON_VERSION"; then
-        echo "Error: The specified Python version $PYTHON_VERSION does not follow the semantic versioning standard."
-        echo "Example of a valid version: 3.8.1, 3.8.1-alpha.1, or 3.8.1+20130313144700"
-        exit 1
-      elif ! python_versions | grep -E "^${PYTHON_VERSION}$" > /dev/null; then
-        echo "Error: Python version $PYTHON_VERSION is not installed."
-        echo "Installed Python versions are:"
-        python_versions
-        exit 1
-      else
-        echo "Using Python version $PYTHON_VERSION"
-      fi
+      # Check the Python version being passed in.
+      check_python_version "$PYTHON_VERSION"
       ;;
     -v | --venv-name)
       VENV_NAME="$2"
@@ -199,7 +217,7 @@ if [ $LIST_VERSIONS -ne 0 ]; then
   # -r: treat backslashes as literal, -p: display prompt before input.
   read -r -p "Enter the desired Python version: " PYTHON_VERSION
   # Check the Python versions being passed in.
-  check_semantic_version "$PYTHON_VERSION"
+  check_python_version "$PYTHON_VERSION"
 fi
 
 # Remove any lingering local configuration.

--- a/setup-env
+++ b/setup-env
@@ -39,12 +39,41 @@ python_versions() {
   pyenv versions --bare --skip-aliases --skip-envs
 }
 
-check_semantic_version() {
+check_python_version() {
   local version=$1
-  local regex="^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?\$"
 
-  # Use Perl for regex matching and output true or false
-  echo "$version" | perl -ne "exit(!/$regex/)"
+  # Break down the regex into readable parts major.minor.patch
+  local major="0|[1-9]\\d*"
+  local minor="0|[1-9]\\d*"
+  local patch="0|[1-9]\\d*"
+
+  # Splitting the prerelease part for readability
+  # Start of prerelease
+  local prerelease="(?:-"
+  # Numeric or alphanumeric identifiers
+  local prerelease+="(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+  # Additional dot-separated identifiers
+  local prerelease+="(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*"
+  # End of prerelease, making it optional
+  local prerelease+=")?"
+  # Optional build metadata
+  local build="(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?"
+
+  # Final regex composed of parts
+  local regex="^($major)\\.($minor)\\.($patch)$prerelease$build\$"
+
+  if ! echo "$version" | perl -ne "exit(!/$regex/)"; then
+    echo "Error: The specified Python version $version does not follow the semantic versioning standard."
+    echo "Example of a valid version: 3.8.1, 3.8.1-alpha.1, or 3.8.1+20130313144700"
+    exit 1
+  elif ! python_versions | grep -E "^${version}$" > /dev/null; then
+    echo "Error: Python version $version is not installed."
+    echo "Installed Python versions are:"
+    python_versions
+    exit 1
+  else
+    echo "Using Python version $version"
+  fi
 }
 
 # Flag to force deletion and creation of virtual environment
@@ -111,19 +140,8 @@ while true; do
     -p | --python-version)
       PYTHON_VERSION="$2"
       shift 2
-      # Validate the semantic version format
-      if ! check_semantic_version "$PYTHON_VERSION"; then
-        echo "Error: The specified Python version $PYTHON_VERSION does not follow the semantic versioning standard."
-        echo "Example of a valid version: 3.8.1, 3.8.1-alpha.1, or 3.8.1+20130313144700"
-        exit 1
-      elif ! python_versions | grep -E "^${PYTHON_VERSION}$" > /dev/null; then
-        echo "Error: Python version $PYTHON_VERSION is not installed."
-        echo "Installed Python versions are:"
-        python_versions
-        exit 1
-      else
-        echo "Using Python version $PYTHON_VERSION"
-      fi
+      # Check the Python version being passed in.
+      check_python_version "$PYTHON_VERSION"
       ;;
     -v | --venv-name)
       VENV_NAME="$2"
@@ -191,7 +209,7 @@ if [ $LIST_VERSIONS -ne 0 ]; then
   python_versions
   read -r -p "Enter the desired Python version: " PYTHON_VERSION
   # Check the Python versions being passed in.
-  check_semantic_version "$PYTHON_VERSION"
+  check_python_version "$PYTHON_VERSION"
 fi
 
 # Remove any lingering local configuration.

--- a/setup-env
+++ b/setup-env
@@ -217,7 +217,7 @@ if [ $LIST_VERSIONS -ne 0 ]; then
   # Read the user's desired Python version.
   # -r: treat backslashes as literal, -p: display prompt before input.
   read -r -p "Enter the desired Python version: " PYTHON_VERSION
-  # Check the Python versions being passed in.
+  # Check the Python version being passed in.
   check_python_version "$PYTHON_VERSION"
 fi
 

--- a/setup-env
+++ b/setup-env
@@ -42,31 +42,38 @@ python_versions() {
 check_python_version() {
   local version=$1
 
+  # This is a valid regex for semantically correct Python version strings.
+  # For more information see here: https://regex101.com/r/vkijKf/1/.
   # Break down the regex into readable parts major.minor.patch
-  local major="0|[1-9]\\d*"
-  local minor="0|[1-9]\\d*"
-  local patch="0|[1-9]\\d*"
+  local major="0|[1-9]\d*"
+  local minor="0|[1-9]\d*"
+  local patch="0|[1-9]\d*"
 
   # Splitting the prerelease part for readability
-  # Start of prerelease
+  # Start of the prerelease
   local prerelease="(?:-"
   # Numeric or alphanumeric identifiers
-  local prerelease+="(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+  local prerelease+="(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
   # Additional dot-separated identifiers
-  local prerelease+="(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*"
-  # End of prerelease, making it optional
+  local prerelease+="(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*"
+  # End of the prerelease, making it optional
   local prerelease+=")?"
   # Optional build metadata
-  local build="(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?"
+  local build="(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
 
   # Final regex composed of parts
-  local regex="^($major)\\.($minor)\\.($patch)$prerelease$build\$"
+  local regex="^($major)\.($minor)\.($patch)$prerelease$build$"
 
+  # This checks if the Python version does not match the regex pattern specified in $regex,
+  # using Perl for regex matching. If the pattern is not found, then prompt the user with
+  # the invalid version message.
   if ! echo "$version" | perl -ne "exit(!/$regex/)"; then
     echo "Invalid version of Python: Python follows semantic versioning," \
       "so any version string that is not a valid semantic version is an" \
       "invalid version of Python."
     exit 1
+  # Else if the Python version isn't installed then notify the user.
+  # grep -E is used for searching through text lines that match the specific verison.
   elif ! python_versions | grep -E "^${version}$" > /dev/null; then
     echo "Error: Python version $version is not installed."
     echo "Installed Python versions are:"

--- a/setup-env
+++ b/setup-env
@@ -43,7 +43,8 @@ check_python_version() {
   local version=$1
 
   # This is a valid regex for semantically correct Python version strings.
-  # For more information see here: https://regex101.com/r/vkijKf/1/.
+  # For more information see here:
+  # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string.
   # Break down the regex into readable parts major.minor.patch
   local major="0|[1-9]\d*"
   local minor="0|[1-9]\d*"

--- a/setup-env
+++ b/setup-env
@@ -39,6 +39,14 @@ python_versions() {
   pyenv versions --bare --skip-aliases --skip-envs
 }
 
+check_semantic_version() {
+  local version=$1
+  local regex="^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?\$"
+
+  # Use Perl for regex matching and output true or false
+  echo "$version" | perl -ne "exit(!/$regex/)"
+}
+
 # Flag to force deletion and creation of virtual environment
 FORCE=0
 
@@ -103,16 +111,18 @@ while true; do
     -p | --python-version)
       PYTHON_VERSION="$2"
       shift 2
-      # Check the Python versions being passed in.
-      if [ -n "${PYTHON_VERSION+x}" ]; then
-        if python_versions | grep -E "^${PYTHON_VERSION}$" > /dev/null; then
-          echo Using Python version "$PYTHON_VERSION"
-        else
-          echo Error: Python version "$PYTHON_VERSION" is not installed.
-          echo Installed Python versions are:
-          python_versions
-          exit 1
-        fi
+      # Validate the semantic version format
+      if ! check_semantic_version "$PYTHON_VERSION"; then
+        echo "Error: The specified Python version $PYTHON_VERSION does not follow the semantic versioning standard."
+        echo "Example of a valid version: 3.8.1, 3.8.1-alpha.1, or 3.8.1+20130313144700"
+        exit 1
+      elif ! python_versions | grep -E "^${PYTHON_VERSION}$" > /dev/null; then
+        echo "Error: Python version $PYTHON_VERSION is not installed."
+        echo "Installed Python versions are:"
+        python_versions
+        exit 1
+      else
+        echo "Using Python version $PYTHON_VERSION"
       fi
       ;;
     -v | --venv-name)
@@ -181,14 +191,7 @@ if [ $LIST_VERSIONS -ne 0 ]; then
   python_versions
   read -r -p "Enter the desired Python version: " PYTHON_VERSION
   # Check the Python versions being passed in.
-  if [ -n "${PYTHON_VERSION+x}" ]; then
-    if python_versions | grep -E "^${PYTHON_VERSION}$" > /dev/null; then
-      echo Using Python version "$PYTHON_VERSION"
-    else
-      echo Error: Python version "$PYTHON_VERSION" is not installed.
-      exit 1
-    fi
-  fi
+  check_semantic_version "$PYTHON_VERSION"
 fi
 
 # Remove any lingering local configuration.

--- a/setup-env
+++ b/setup-env
@@ -64,7 +64,6 @@ check_python_version() {
 
   if ! echo "$version" | perl -ne "exit(!/$regex/)"; then
     echo "Error: The specified Python version $version does not follow the semantic versioning standard."
-    echo "Example of a valid version: 3.8.1, 3.8.1-alpha.1, or 3.8.1+20130313144700"
     exit 1
   elif ! python_versions | grep -E "^${version}$" > /dev/null; then
     echo "Error: Python version $version is not installed."

--- a/setup-env
+++ b/setup-env
@@ -44,7 +44,7 @@ check_python_version() {
 
   # This is a valid regex for semantically correct Python version strings.
   # For more information see here:
-  # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string.
+  # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
   # Break down the regex into readable parts major.minor.patch
   local major="0|[1-9]\d*"
   local minor="0|[1-9]\d*"

--- a/setup-env
+++ b/setup-env
@@ -39,6 +39,14 @@ python_versions() {
   pyenv versions --bare --skip-aliases --skip-envs
 }
 
+check_semantic_version() {
+  local version=$1
+  local regex="^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?\$"
+
+  # Use Perl for regex matching and output true or false
+  echo "$version" | perl -ne "exit(!/$regex/)"
+}
+
 # Flag to force deletion and creation of virtual environment
 FORCE=0
 
@@ -144,16 +152,18 @@ while true; do
     -p | --python-version)
       PYTHON_VERSION="$2"
       shift 2
-      # Check the Python versions being passed in.
-      if [ -n "${PYTHON_VERSION+x}" ]; then
-        if python_versions | grep -E "^${PYTHON_VERSION}$" > /dev/null; then
-          echo Using Python version "$PYTHON_VERSION"
-        else
-          echo Error: Python version "$PYTHON_VERSION" is not installed.
-          echo Installed Python versions are:
-          python_versions
-          exit 1
-        fi
+      # Validate the semantic version format
+      if ! check_semantic_version "$PYTHON_VERSION"; then
+        echo "Error: The specified Python version $PYTHON_VERSION does not follow the semantic versioning standard."
+        echo "Example of a valid version: 3.8.1, 3.8.1-alpha.1, or 3.8.1+20130313144700"
+        exit 1
+      elif ! python_versions | grep -E "^${PYTHON_VERSION}$" > /dev/null; then
+        echo "Error: Python version $PYTHON_VERSION is not installed."
+        echo "Installed Python versions are:"
+        python_versions
+        exit 1
+      else
+        echo "Using Python version $PYTHON_VERSION"
       fi
       ;;
     -v | --venv-name)
@@ -189,14 +199,7 @@ if [ $LIST_VERSIONS -ne 0 ]; then
   # -r: treat backslashes as literal, -p: display prompt before input.
   read -r -p "Enter the desired Python version: " PYTHON_VERSION
   # Check the Python versions being passed in.
-  if [ -n "${PYTHON_VERSION+x}" ]; then
-    if python_versions | grep -E "^${PYTHON_VERSION}$" > /dev/null; then
-      echo Using Python version "$PYTHON_VERSION"
-    else
-      echo Error: Python version "$PYTHON_VERSION" is not installed.
-      exit 1
-    fi
-  fi
+  check_semantic_version "$PYTHON_VERSION"
 fi
 
 # Remove any lingering local configuration.

--- a/setup-env
+++ b/setup-env
@@ -63,8 +63,8 @@ check_python_version() {
   local regex="^($major)\\.($minor)\\.($patch)$prerelease$build\$"
 
   if ! echo "$version" | perl -ne "exit(!/$regex/)"; then
-    echo "Invalid version of Python: Python follows semantic versioning, " \
-      "so any version string that is not a valid semantic version is an " \
+    echo "Invalid version of Python: Python follows semantic versioning," \
+      "so any version string that is not a valid semantic version is an" \
       "invalid version of Python."
     exit 1
   elif ! python_versions | grep -E "^${version}$" > /dev/null; then


### PR DESCRIPTION
## 🗣 Description ##

Now if a user enters an incorrect semantic version of Python they will get the following message:
_"Invalid version of Python: Python follows semantic versioning, so any version string that is not a valid semantic version is an invalid version of Python."_

## 💭 Motivation and context ##

This PR will address the issue here: https://github.com/cisagov/skeleton-generic/issues/167.

## 🧪 Testing ##

I tested this by making a testing script that verified the following examples were valid or invalid semantic versions:

**Valid Semantic Versions**

```
0.0.4
1.2.3
10.20.30
1.1.2-prerelease+meta
1.1.2+meta
1.1.2+meta-valid
1.0.0-alpha
1.0.0-beta
1.0.0-alpha.beta
1.0.0-alpha.beta.1
1.0.0-alpha.1
1.0.0-alpha0.valid
1.0.0-alpha.0valid
1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay
1.0.0-rc.1+build.1
2.0.0-rc.1+build.123
1.2.3-beta
10.2.3-DEV-SNAPSHOT
1.2.3-SNAPSHOT-123
1.0.0
2.0.0
1.1.7
2.0.0+build.1848
2.0.1-alpha.1227
1.0.0-alpha+beta
1.2.3----RC-SNAPSHOT.12.9.1--.12+788
1.2.3----R-S.12.9.1--.12+meta
1.2.3----RC-SNAPSHOT.12.9.1--.12
1.0.0+0.build.1-rc.10000aaa-kk-0.1
99999999999999999999999.999999999999999999.99999999999999999
1.0.0-0A.is.legal
```

**Invalid Semantic Versions**

```
1
1.2
1.2.3-0123
1.2.3-0123.0123
1.1.2+.123
+invalid
-invalid
-invalid+invalid
-invalid.01
alpha
alpha.beta
alpha.beta.1
alpha.1
alpha+beta
alpha_beta
alpha.
alpha..
beta
1.0.0-alpha_beta
-alpha.
1.0.0-alpha..
1.0.0-alpha..1
1.0.0-alpha...1
1.0.0-alpha....1
1.0.0-alpha.....1
1.0.0-alpha......1
1.0.0-alpha.......1
01.1.1
1.01.1
1.1.01
1.2
1.2.3.DEV
1.2-SNAPSHOT
1.2.31.2.3----RC-SNAPSHOT.12.09.1--..12+788
1.2-RC-SNAPSHOT
-1.0.3-gamma+b7718
+justmeta
9.8.7+meta+meta
9.8.7-whatever+meta+meta
99999999999999999999999.999999999999999999.99999999999999999----RC-SNAPSHOT.12.09.1--------------------------------..12
```

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
