### PR TITLE
Pin package for `ansible-lint` in `pre-commit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,6 +156,14 @@ repos:
     hooks:
       - id: ansible-lint
         additional_dependencies:
+          # On its own ansible-lint does not pull in ansible, only
+          # ansible-core.  Therefore, if an Ansible module lives in
+          # ansible instead of ansible-core, the linter will complain
+          # that the module is unknown.  In these cases it is
+          # necessary to add the ansible package itself as an
+          # additional dependency, with the same pinning as is done in
+          # requirements-test.txt of cisagov/skeleton-ansible-role.
+          # - ansible
           # TODO: Remove this pin when that becomes possible.  See
           # cisagov/skeleton-generic#181 for more details.
           #

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -171,7 +171,6 @@ repos:
           # in requirements.txt in cisagov/skeleton-packer and
           # requirements-test.txt in cisagov/skeleton-ansible-role.
           - ansible-core<2.16.3
-      # files: molecule/default/playbook.yml
 
   # Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,6 +155,22 @@ repos:
     rev: v24.2.0
     hooks:
       - id: ansible-lint
+        additional_dependencies:
+          # TODO: Remove this pin when that becomes possible.  See
+          # cisagov/skeleton-generic#181 for more details.
+          #
+          # Since we pin ansible-core in
+          # cisagov/skeleton-ansible-role, we should pin it here too
+          # to ensure that ansible-lint is applied consistently across
+          # all our repos.  See cisagov/skeleton-ansible-role#178 for
+          # more information as to why this pinning is necessary.
+          #
+          # See also cisagov/skeleton-packer#312 and
+          # cisagov/skeleton-ansible-role#179.  Note from these PRs
+          # that any changes made to this dependency must also be made
+          # in requirements.txt in cisagov/skeleton-packer and
+          # requirements-test.txt in cisagov/skeleton-ansible-role.
+          - ansible-core<2.16.3
       # files: molecule/default/playbook.yml
 
   # Terraform hooks


### PR DESCRIPTION
## 🗣 Description ##

This pull request pins `ansible-core` when running `ansible-lint` in `pre-commit`.  It also adds a comment explaining why the Python package `ansible` may sometimes need to be added as an additional dependency for the `ansible-lint` linter in `.pre-commit-config.yaml`.

## 💭 Motivation and context ##

This is done to match the pinning that was done in cisagov/skeleton-ansible-role#193.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.