### PR TITLE
Pin packages for `ansible-lint`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -163,7 +163,7 @@ repos:
           # necessary to add the ansible package itself as an
           # additional dependency, with the same pinning as is done in
           # requirements-test.txt of cisagov/skeleton-ansible-role.
-          # - ansible>=8,<10
+          # - ansible>=9,<10
           # ansible-core 2.16.3 through 2.16.6 suffer from the bug
           # discussed in ansible/ansible#82702, which breaks any
           # symlinked files in vars, tasks, etc. for any Ansible role

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -155,6 +155,17 @@ repos:
     rev: v24.2.0
     hooks:
       - id: ansible-lint
+        additional_dependencies:
+          # ansible-core 2.16.3 through 2.16.6 suffer from the bug
+          # discussed in ansible/ansible#82702, which breaks any
+          # symlinked files in vars, tasks, etc. for any Ansible role
+          # installed via ansible-galaxy.  Hence we never want to
+          # install those versions.
+          #
+          # Note that any changes made to this dependency must also be
+          # made in requirements.txt in cisagov/skeleton-packer and
+          # requirements-test.txt in cisagov/skeleton-ansible-role.
+          - ansible-core>=2.16.7
       # files: molecule/default/playbook.yml
 
   # Terraform hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,6 +156,14 @@ repos:
     hooks:
       - id: ansible-lint
         additional_dependencies:
+          # On its own ansible-lint does not pull in ansible, only
+          # ansible-core.  Therefore, if an Ansible module lives in
+          # ansible instead of ansible-core, the linter will complain
+          # that the module is unknown.  In these cases it is
+          # necessary to add the ansible package itself as an
+          # additional dependency, with the same pinning as is done in
+          # requirements-test.txt of cisagov/skeleton-ansible-role.
+          # - ansible>=8,<10
           # ansible-core 2.16.3 through 2.16.6 suffer from the bug
           # discussed in ansible/ansible#82702, which breaks any
           # symlinked files in vars, tasks, etc. for any Ansible role

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -166,7 +166,6 @@ repos:
           # made in requirements.txt in cisagov/skeleton-packer and
           # requirements-test.txt in cisagov/skeleton-ansible-role.
           - ansible-core>=2.16.7
-      # files: molecule/default/playbook.yml
 
   # Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the current version pin on the `ansible-core` Python package, replacing it with a lower bound that guarantees we will never use the problematic versions.

## 💭 Motivation and context ##

We can do this because new versions of the `ansible-core` Python package (2.16.7 and 2.17.0) have been released that do not suffer from the bug discussed in ansible/ansible#82702. This bug broke any symlinked files in vars, tasks, etc. for any Ansible role installed via `ansible-galaxy`.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.