### PR TITLE
Add a lower-bound pin for the `flake8-docstrings` `pip` package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,7 +136,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-docstrings>=1.7.0
+          - flake8-docstrings==1.7.0
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,7 +136,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-docstrings
+          - flake8-docstrings>=1.7.0
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:


### PR DESCRIPTION
## 🗣 Description ##

I noticed that `flake8-docstrings` is listed as an additional dependency of `flake8` in the `pre-commit` configuration, but pinning is done.

## 💭 Motivation and context ##

@mcdonnnj agreed with me that it makes sense to at least perform some minimal pinning to ensure that a working version of `flake8-docstrings` is installed.

## 🧪 Testing ##

All automated tests pass.  I also verified that there are no other additional dependencies in the `pre-commit` configuration that do no at least have a lower-bound pin.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.