### PR TITLE
Switch the `pre-commit` hook used to run `prettier`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,17 +40,10 @@ repos:
       - id: markdownlint
         args:
           - --config=.mdl_config.yaml
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    # This is the last version of v3 available from the mirror. We should hold
-    # here until v4, which is currently in alpha, is more stable.
-    rev: v3.1.0
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.3.3
     hooks:
       - id: prettier
-        # This is the latest version of v3 available from NPM. The pre-commit
-        # mirror does not pull tags for old major versions once a new major
-        # version tag is published.
-        additional_dependencies:
-          - prettier@3.3.3
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.35.1
     hooks:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request switches the [pre-commit] hook used to run [prettier] from [pre-commit/mirrors-prettier] to [rbubley/mirrors-prettier].
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The [pre-commit/mirrors-prettier] hook has been archived due to changes in the upcoming [prettier] v4 that "break plugins entirely".  A longstanding gripe I have had with the hook is that as soon as a pre-release is cut (basically the first alpha release), the older stable major version no longer gets updated tags. The new hook ignores pre-releases and, so far at least, is only cutting tags for the v3 point releases.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[pre-commit/mirrors-prettier]: https://github.com/detailyang/pre-commit-shell
[pre-commit]: https://pre-commit.com
[prettier]: https://github.com/prettier/prettier
[rbubley/mirrors-prettier]: https://github.com/shellcheck-py/shellcheck-py