### PR TITLE
Remove @jasonodoom as a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,22 +3,22 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+* @dav3r @felddy @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.
-/.github/ @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/.github/ @dav3r @felddy @jsf9k @mcdonnnj
 
 # These folks own all linting configuration files.
-/.ansible-lint @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
-/.bandit.yml @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
-/.flake8 @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
-/.isort.cfg @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
-/.mdl_config.yaml @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
-/.pre-commit-config.yaml @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
-/.prettierignore @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
-/.yamllint @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
-/requirements.txt @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
-/requirements-dev.txt @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
-/requirements-test.txt @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
-/setup-env @dav3r @felddy @jasonodoom @jsf9k @mcdonnnj
+/.ansible-lint @dav3r @felddy @jsf9k @mcdonnnj
+/.bandit.yml @dav3r @felddy @jsf9k @mcdonnnj
+/.flake8 @dav3r @felddy @jsf9k @mcdonnnj
+/.isort.cfg @dav3r @felddy @jsf9k @mcdonnnj
+/.mdl_config.yaml @dav3r @felddy @jsf9k @mcdonnnj
+/.pre-commit-config.yaml @dav3r @felddy @jsf9k @mcdonnnj
+/.prettierignore @dav3r @felddy @jsf9k @mcdonnnj
+/.yamllint @dav3r @felddy @jsf9k @mcdonnnj
+/requirements.txt @dav3r @felddy @jsf9k @mcdonnnj
+/requirements-dev.txt @dav3r @felddy @jsf9k @mcdonnnj
+/requirements-test.txt @dav3r @felddy @jsf9k @mcdonnnj
+/setup-env @dav3r @felddy @jsf9k @mcdonnnj


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes @jasonodoom from the `CODEOWNERS` file.

## 💭 Motivation and context ##

He is no longer a member of @cisagov/vm-dev.

## 🧪 Testing ##

I tested via my ocular orbs.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.