### PR TITLE
Allow the `sync-labels` workflow to be run manually

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/labels.yml'
       - '.github/workflows/sync-labels.yml'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -4,8 +4,8 @@ name: sync-labels
 on:
   push:
     paths:
-      - '.github/labels.yml'
-      - '.github/workflows/sync-labels.yml'
+      - .github/labels.yml
+      - .github/workflows/sync-labels.yml
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a `workflow_dispatch` trigger to the `sync-labels` workflow.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The `workflow_dispatch` trigger allows the workflow to be manually initiated. This will allow us to force an update on a repository's tags if they are, for whatever reason, out of sync with the configuration in `.github/labels.yml`.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
