### PR TITLE
Add missing dependabot ignore directives

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,12 @@ updates:
     #   - dependency-name: actions/checkout
     #   - dependency-name: actions/setup-go
     #   - dependency-name: actions/setup-python
+    #   - dependency-name: cisagov/setup-env-github-action
     #   - dependency-name: crazy-max/ghaction-dump-context
     #   - dependency-name: crazy-max/ghaction-github-labeler
     #   - dependency-name: crazy-max/ghaction-github-status
     #   - dependency-name: GitHubSecurityLab/actions-permissions
+    #   - dependency-name: hashicorp/setup-packer
     #   - dependency-name: hashicorp/setup-terraform
     #   - dependency-name: mxschmitt/action-tmate
     #   - dependency-name: step-security/harden-runner


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request ensures that every Action we use in our workflows has a corresponding dependabot ignore directive.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I noticed that I missed adding the appropriate directive for [hashicorp/setup-packer] in #187. I also decided to add one for [cisagov/setup-env-github-action] just to be comprehensive. We currently pull the `develop` branch so dependabot should never trigger pull requests around this dependency, but we might decide to start versioning that Action in the future so it's better to list it as a precautionary measure.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[cisagov/setup-env-github-action]: https://github.com/cisagov/setup-env-github-action
[hashicorp/setup-packer]: https://github.com/hashicorp/setup-packer
