### PR TITLE
Bump up the lower bound on `ansible-core`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -189,12 +189,14 @@ repos:
           # install those versions.
           #
           # Note that the pip-audit pre-commit hook identifies a
-          # vulnerability in ansible-core 2.16.13.
+          # vulnerability in ansible-core 2.16.13.  The pin of
+          # ansible-core to >=2.17 effectively also pins ansible to
+          # >=10.
           #
           # Note that any changes made to this dependency must also be
           # made in requirements.txt in cisagov/skeleton-packer and
           # requirements-test.txt in cisagov/skeleton-ansible-role.
-          - ansible-core>2.16.13
+          - ansible-core>=2.17
 
   # Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -176,17 +176,25 @@ repos:
           # necessary to add the ansible package itself as an
           # additional dependency, with the same pinning as is done in
           # requirements-test.txt of cisagov/skeleton-ansible-role.
-          # - ansible>=9,<10
+          #
+          # Version 10 is required because the pip-audit pre-commit
+          # hook identifies a vulnerability in ansible-core 2.16.13,
+          # but all versions of ansible 9 have a dependency on
+          # ~=2.16.X.
+          # - ansible>=10,<11
           # ansible-core 2.16.3 through 2.16.6 suffer from the bug
           # discussed in ansible/ansible#82702, which breaks any
           # symlinked files in vars, tasks, etc. for any Ansible role
           # installed via ansible-galaxy.  Hence we never want to
           # install those versions.
           #
+          # Note that the pip-audit pre-commit hook identifies a
+          # vulnerability in ansible-core 2.16.13.
+          #
           # Note that any changes made to this dependency must also be
           # made in requirements.txt in cisagov/skeleton-packer and
           # requirements-test.txt in cisagov/skeleton-ansible-role.
-          - ansible-core>=2.16.7
+          - ansible-core>2.16.13
 
   # Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -181,6 +181,10 @@ repos:
           # hook identifies a vulnerability in ansible-core 2.16.13,
           # but all versions of ansible 9 have a dependency on
           # ~=2.16.X.
+          #
+          # It is also a good idea to go ahead and upgrade to version
+          # 10 since version 9 is going EOL at the end of November:
+          # https://endoflife.date/ansible
           # - ansible>=10,<11
           # ansible-core 2.16.3 through 2.16.6 suffer from the bug
           # discussed in ansible/ansible#82702, which breaks any
@@ -192,6 +196,11 @@ repos:
           # vulnerability in ansible-core 2.16.13.  The pin of
           # ansible-core to >=2.17 effectively also pins ansible to
           # >=10.
+          #
+          # It is also a good idea to go ahead and upgrade to
+          # ansible-core 2.17 since security support for ansible-core
+          # 2.16 ends this month:
+          # https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
           #
           # Note that any changes made to this dependency must also be
           # made in requirements.txt in cisagov/skeleton-packer and


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps up the lower bound on the `ansible-core` Python package.

See also cisagov/skeleton-ansible-role#209 and the commits cisagov/skeleton-packer@26a8bafe25f49a099a07342a1539e4dd6eb60095 and cisagov/skeleton-packer@19fbaf3e1a6da801ce796509b8187ff1aa541d43 in cisagov/skeleton-packer#376.

## 💭 Motivation and context ##

This is being done because the `pip-audit` `pre-commit` hook identifies a vulnerability in `ansible-core` version 2.16.13.  Note that this requires that we bump up the version of `ansible` to version 10 since all versions of `ansible` 9 have a dependency on `ansible-core~=2.16.X`.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
