### PR TITLE
Update the version of the `ansible-lint` `pre-commit` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -165,7 +165,7 @@ repos:
 
   # Ansible hooks
   - repo: https://github.com/ansible/ansible-lint
-    rev: v24.9.2
+    rev: v24.10.0
     hooks:
       - id: ansible-lint
         additional_dependencies:


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the version of the `ansible-lint` `pre-commit` hook.

## 💭 Motivation and context ##

Version 24.10.0 is the first version that supports Fedora 41 as a valid platform.  We want to add support for Fedora 41 in cisagov/skeleton-ansible-role#207.

## 🧪 Testing ##

All automated tests pass.  These changes were also tested as part of cisagov/skeleton-ansible-role#207.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.