### PR TITLE
Bump up ansible-core and ansible pins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -177,35 +177,20 @@ repos:
           # additional dependency, with the same pinning as is done in
           # requirements-test.txt of cisagov/skeleton-ansible-role.
           #
-          # Version 10 is required because the pip-audit pre-commit
-          # hook identifies a vulnerability in ansible-core 2.16.13,
-          # but all versions of ansible 9 have a dependency on
-          # ~=2.16.X.
-          #
-          # It is also a good idea to go ahead and upgrade to version
-          # 10 since version 9 is going EOL at the end of November:
-          # https://endoflife.date/ansible
-          # - ansible>=10,<11
-          # ansible-core 2.16.3 through 2.16.6 suffer from the bug
-          # discussed in ansible/ansible#82702, which breaks any
-          # symlinked files in vars, tasks, etc. for any Ansible role
-          # installed via ansible-galaxy.  Hence we never want to
-          # install those versions.
-          #
+          # Version 11 is required because the pip-audit pre-commit
+          # hook identifies a vulnerability (GHSA-99w6-3xph-cx78) in
+          # ansible-core<=2.18.0, but all versions of ansible 10 have a
+          # dependency on ~=2.17.X.
+          # - ansible>=11,<12
           # Note that the pip-audit pre-commit hook identifies a
-          # vulnerability in ansible-core 2.16.13.  The pin of
-          # ansible-core to >=2.17 effectively also pins ansible to
-          # >=10.
-          #
-          # It is also a good idea to go ahead and upgrade to
-          # ansible-core 2.17 since security support for ansible-core
-          # 2.16 ends this month:
-          # https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
+          # vulnerability (GHSA-99w6-3xph-cx78) in ansible-core
+          # 2.18.0.  The pin of ansible-core to >=2.18.1 effectively
+          # also pins ansible to >=11.
           #
           # Note that any changes made to this dependency must also be
           # made in requirements.txt in cisagov/skeleton-packer and
           # requirements-test.txt in cisagov/skeleton-ansible-role.
-          - ansible-core>=2.17
+          - ansible-core>=2.18.1
 
   # Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps up the `ansible-core` and `ansible` pins.

## 💭 Motivation and context ##

Version 2.18.1 of `ansible-core` is required because the `pip-audit` `pre-commit` hook identifies a vulnerability (GHSA-99w6-3xph-cx78) in `ansible-core<=2.18.1`.  This in turn necessitates an upgrade to at least `ansible` 11.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.