### PR TITLE
Apply our standard job preamble via cisagov/action-job-preamble

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     #   - dependency-name: actions/checkout
     #   - dependency-name: actions/setup-go
     #   - dependency-name: actions/setup-python
+    #   - dependency-name: cisagov/action-job-preamble
     #   - dependency-name: cisagov/setup-env-github-action
     #   - dependency-name: crazy-max/ghaction-dump-context
     #   - dependency-name: crazy-max/ghaction-github-labeler

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,11 +18,9 @@ updates:
     #   - dependency-name: crazy-max/ghaction-dump-context
     #   - dependency-name: crazy-max/ghaction-github-labeler
     #   - dependency-name: crazy-max/ghaction-github-status
-    #   - dependency-name: GitHubSecurityLab/actions-permissions
     #   - dependency-name: hashicorp/setup-packer
     #   - dependency-name: hashicorp/setup-terraform
     #   - dependency-name: mxschmitt/action-tmate
-    #   - dependency-name: step-security/harden-runner
     package-ecosystem: github-actions
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,7 @@ updates:
     #   - dependency-name: actions/setup-python
     #   - dependency-name: cisagov/action-job-preamble
     #   - dependency-name: cisagov/setup-env-github-action
-    #   - dependency-name: crazy-max/ghaction-dump-context
     #   - dependency-name: crazy-max/ghaction-github-labeler
-    #   - dependency-name: crazy-max/ghaction-github-status
     #   - dependency-name: hashicorp/setup-packer
     #   - dependency-name: hashicorp/setup-terraform
     #   - dependency-name: mxschmitt/action-tmate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
         with:
+          # Use the cisagov organization variable containing the
+          # organization-wide permissions monitoring configuration.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: github-status
         name: Check GitHub status
@@ -57,6 +59,8 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
         with:
+          # Use the cisagov organization variable containing the
+          # organization-wide permissions monitoring configuration.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: setup-env
         uses: cisagov/setup-env-github-action@develop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@first-commits
         with:
-          actions_permissions_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: github-status
         name: Check GitHub status
         uses: crazy-max/ghaction-github-status@v4
@@ -57,7 +57,7 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@first-commits
         with:
-          actions_permissions_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: setup-env
         uses: cisagov/setup-env-github-action@develop
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,8 @@ jobs:
     steps:
       # Note that a duplicate of this step must be added at the top of
       # each job.
-      - uses: cisagov/action-job-preamble@first-commits
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@first-commits
         with:
           actions_permissions_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: github-status
@@ -53,7 +54,8 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: cisagov/action-job-preamble@first-commits
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@first-commits
         with:
           actions_permissions_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: setup-env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
       # Note that a duplicate of this step must be added at the top of
       # each job.
       - uses: cisagov/action-job-preamble@first-commits
+        with:
+          actions_permissions_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: github-status
         name: Check GitHub status
         uses: crazy-max/ghaction-github-status@v4
@@ -52,6 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: cisagov/action-job-preamble@first-commits
+        with:
+          actions_permissions_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: setup-env
         uses: cisagov/setup-env-github-action@develop
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
         with:
+          check_github_status: "true"
+          # This functionality is poorly implemented and has been
+          # causing a lot of problems due to the MITM implementation
+          # hogging or leaking memory, so we disable it for now.
+          monitor_permissions: "false"
+          output_workflow_context: "true"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
           # configuration stored in the cisagov organization-level
@@ -53,12 +59,6 @@ jobs:
           # monitoring configuration *does not* require you to modify
           # this workflow.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
-      - id: github-status
-        name: Check GitHub status
-        uses: crazy-max/ghaction-github-status@v4
-      - id: dump-context
-        name: Dump context
-        uses: crazy-max/ghaction-dump-context@v2
   lint:
     needs:
       - diagnostics
@@ -70,6 +70,10 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
         with:
+          # This functionality is poorly implemented and has been
+          # causing a lot of problems due to the MITM implementation
+          # hogging or leaking memory, so we disable it for now.
+          monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
           # configuration stored in the cisagov organization-level

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       # Note that a duplicate of this step must be added at the top of
       # each job.
       - name: Apply standard cisagov job preamble
-        uses: cisagov/action-job-preamble@first-commits
+        uses: cisagov/action-job-preamble@v1
         with:
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: github-status
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply standard cisagov job preamble
-        uses: cisagov/action-job-preamble@first-commits
+        uses: cisagov/action-job-preamble@v1
         with:
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: setup-env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,19 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
         with:
-          # Use the cisagov organization variable containing the
-          # organization-wide permissions monitoring configuration.
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: github-status
         name: Check GitHub status
@@ -59,8 +70,19 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
         with:
-          # Use the cisagov organization variable containing the
-          # organization-wide permissions monitoring configuration.
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: setup-env
         uses: cisagov/setup-env-github-action@develop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,17 +36,7 @@ jobs:
     steps:
       # Note that a duplicate of this step must be added at the top of
       # each job.
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          # Uses the organization variable unless overridden
-          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
-      # Note that a duplicate of this step must be added at the top of
-      # each job.
-      - id: harden-runner
-        name: Harden the runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
+      - uses: cisagov/action-job-preamble@first-commits
       - id: github-status
         name: Check GitHub status
         uses: crazy-max/ghaction-github-status@v4
@@ -61,15 +51,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          # Uses the organization variable unless overridden
-          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
-      - id: harden-runner
-        name: Harden the runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
+      - uses: cisagov/action-job-preamble@first-commits
       - id: setup-env
         uses: cisagov/setup-env-github-action@develop
       - uses: actions/checkout@v4

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
         with:
+          check_github_status: "true"
+          # This functionality is poorly implemented and has been
+          # causing a lot of problems due to the MITM implementation
+          # hogging or leaking memory, so we disable it for now.
+          monitor_permissions: "false"
+          output_workflow_context: "true"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
           # configuration stored in the cisagov organization-level
@@ -37,12 +43,6 @@ jobs:
           # monitoring configuration *does not* require you to modify
           # this workflow.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
-      - id: github-status
-        name: Check GitHub status
-        uses: crazy-max/ghaction-github-status@v4
-      - id: dump-context
-        name: Dump context
-        uses: crazy-max/ghaction-dump-context@v2
   labeler:
     needs:
       - diagnostics
@@ -56,6 +56,10 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
         with:
+          # This functionality is poorly implemented and has been
+          # causing a lot of problems due to the MITM implementation
+          # hogging or leaking memory, so we disable it for now.
+          monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
           # configuration stored in the cisagov organization-level

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -21,7 +21,7 @@ jobs:
       # Note that a duplicate of this step must be added at the top of
       # each job.
       - name: Apply standard cisagov job preamble
-        uses: cisagov/action-job-preamble@first-commits
+        uses: cisagov/action-job-preamble@v1
         with:
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: github-status
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply standard cisagov job preamble
-        uses: cisagov/action-job-preamble@first-commits
+        uses: cisagov/action-job-preamble@v1
         with:
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - uses: actions/checkout@v4

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -23,8 +23,19 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
         with:
-          # Use the cisagov organization variable containing the
-          # organization-wide permissions monitoring configuration.
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: github-status
         name: Check GitHub status
@@ -45,8 +56,19 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
         with:
-          # Use the cisagov organization variable containing the
-          # organization-wide permissions monitoring configuration.
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - uses: actions/checkout@v4
       - name: Sync repository labels

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -20,17 +20,10 @@ jobs:
     steps:
       # Note that a duplicate of this step must be added at the top of
       # each job.
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@first-commits
         with:
-          # Uses the organization variable unless overridden
-          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
-      # Note that a duplicate of this step must be added at the top of
-      # each job.
-      - id: harden-runner
-        name: Harden the runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: github-status
         name: Check GitHub status
         uses: crazy-max/ghaction-github-status@v4
@@ -47,15 +40,10 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@first-commits
         with:
-          # Uses the organization variable unless overridden
-          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
-      - id: harden-runner
-        name: Harden the runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - uses: actions/checkout@v4
       - name: Sync repository labels
         if: success()

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
         with:
+          # Use the cisagov organization variable containing the
+          # organization-wide permissions monitoring configuration.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: github-status
         name: Check GitHub status
@@ -43,6 +45,8 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
         with:
+          # Use the cisagov organization variable containing the
+          # organization-wide permissions monitoring configuration.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - uses: actions/checkout@v4
       - name: Sync repository labels


### PR DESCRIPTION
## 🗣 Description ##

This pull request leverages the [cisagov/action-job-preamble](https://github.com/cisagov/action-job-preamble) GitHub Action to apply our standard permissions monitoring and runner hardening to each GitHub Actions job.

## 💭 Motivation and context ##

Using [cisagov/action-job-preamble](https://github.com/cisagov/action-job-preamble) allows us to DRY out the GitHub Actions workflows in our skeleton repositories a bit.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Use the `v1` tag of [cisagov/action-job-preamble](https://github.com/cisagov/action-job-preamble) once cisagov/action-job-preamble#1 is approved and merged.
