### PR TITLE
Add a workflow to run `actions/dependency-review-action`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     #   # Managed by cisagov/skeleton-generic
     #   - dependency-name: actions/cache
     #   - dependency-name: actions/checkout
+    #   - dependency-name: actions/dependency-review-action
     #   - dependency-name: actions/setup-go
     #   - dependency-name: actions/setup-python
     #   - dependency-name: cisagov/action-job-preamble

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,67 @@
+---
+name: Dependency review
+
+on:
+  merge_group:
+    types:
+      - checks_requested
+  pull_request:
+
+# Set a default shell for any run steps. The `-Eueo pipefail` sets errtrace,
+# nounset, errexit, and pipefail. The `-x` will print all commands as they are
+# run. Please see the GitHub Actions documentation for more information:
+# https://docs.github.com/en/actions/using-jobs/setting-default-values-for-jobs
+defaults:
+  run:
+    shell: bash -Eueo pipefail -x {0}
+
+jobs:
+  diagnostics:
+    name: Run diagnostics
+    # This job does not need any permissions
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      # Note that a duplicate of this step must be added at the top of
+      # each job.
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          # Uses the organization variable unless overridden
+          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      # Note that a duplicate of this step must be added at the top of
+      # each job.
+      - id: harden-runner
+        name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - id: github-status
+        name: Check GitHub status
+        uses: crazy-max/ghaction-github-status@v4
+      - id: dump-context
+        name: Dump context
+        uses: crazy-max/ghaction-dump-context@v2
+  dependency-review:
+    name: Dependency review
+    needs:
+      - diagnostics
+    permissions:
+      # actions/checkout needs this to fetch code
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          # Uses the organization variable unless overridden
+          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      - id: harden-runner
+        name: Harden the runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - id: checkout-repo
+        name: Checkout the repository
+        uses: actions/checkout@v4
+      - id: dependency-review
+        name: Review dependency changes for vulnerabilities and license changes
+        uses: actions/dependency-review-action@v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,7 +1,7 @@
 ---
 name: Dependency review
 
-on:
+on:  # yamllint disable-line rule:truthy
   merge_group:
     types:
       - checks_requested
@@ -27,6 +27,12 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
         with:
+          check_github_status: "true"
+          # This functionality is poorly implemented and has been
+          # causing a lot of problems due to the MITM implementation
+          # hogging or leaking memory, so we disable it for now.
+          monitor_permissions: "false"
+          output_workflow_context: "true"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
           # configuration stored in the cisagov organization-level
@@ -41,12 +47,6 @@ jobs:
           # monitoring configuration *does not* require you to modify
           # this workflow.
           permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
-      - id: github-status
-        name: Check GitHub status
-        uses: crazy-max/ghaction-github-status@v4
-      - id: dump-context
-        name: Dump context
-        uses: crazy-max/ghaction-dump-context@v2
   dependency-review:
     name: Dependency review
     needs:
@@ -59,6 +59,10 @@ jobs:
       - name: Apply standard cisagov job preamble
         uses: cisagov/action-job-preamble@v1
         with:
+          # This functionality is poorly implemented and has been
+          # causing a lot of problems due to the MITM implementation
+          # hogging or leaking memory, so we disable it for now.
+          monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
           # configuration stored in the cisagov organization-level

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,17 +24,23 @@ jobs:
     steps:
       # Note that a duplicate of this step must be added at the top of
       # each job.
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
         with:
-          # Uses the organization variable unless overridden
-          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
-      # Note that a duplicate of this step must be added at the top of
-      # each job.
-      - id: harden-runner
-        name: Harden the runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: github-status
         name: Check GitHub status
         uses: crazy-max/ghaction-github-status@v4
@@ -50,15 +56,23 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - name: Apply standard cisagov job preamble
+        uses: cisagov/action-job-preamble@v1
         with:
-          # Uses the organization variable unless overridden
-          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
-      - id: harden-runner
-        name: Harden the runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
+          # Use a variable to specify the permissions monitoring
+          # configuration. By default this will yield the
+          # configuration stored in the cisagov organization-level
+          # variable, but if you want to use a different configuration
+          # then simply:
+          # 1. Create a repository-level variable with the name
+          # ACTIONS_PERMISSIONS_CONFIG.
+          # 2. Set this new variable's value to the configuration you
+          # want to use for this repository.
+          #
+          # Note in particular that changing the permissions
+          # monitoring configuration *does not* require you to modify
+          # this workflow.
+          permissions_monitoring_config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: checkout-repo
         name: Checkout the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a workflow to run [actions/dependency-review-action](https://github.com/actions/dependency-review-action).

## 💭 Motivation and context ##

[actions/dependency-review-action](https://github.com/actions/dependency-review-action) reviews dependency changes for vulnerabilities and license changes.

## 🧪 Testing ##

All automated tests pass.  See also [this workflow run](https://github.com/cisagov/skeleton-generic/actions/runs/13612236131/job/38050898083).

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Mark the dependency review check as required.