### PR TITLE
Do not disable GitHub permissions monitoring by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,10 @@ jobs:
         with:
           check_github_status: "true"
           # This functionality is poorly implemented and has been
-          # causing a lot of problems due to the MITM implementation
-          # hogging or leaking memory, so we disable it for now.
-          monitor_permissions: "false"
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  If this happens to you just uncomment
+          # this line.
+          # monitor_permissions: "false"
           output_workflow_context: "true"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
@@ -71,9 +72,10 @@ jobs:
         uses: cisagov/action-job-preamble@v1
         with:
           # This functionality is poorly implemented and has been
-          # causing a lot of problems due to the MITM implementation
-          # hogging or leaking memory, so we disable it for now.
-          monitor_permissions: "false"
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  If this happens to you just uncomment
+          # this line.
+          # monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
           # configuration stored in the cisagov organization-level

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,9 +38,10 @@ jobs:
         with:
           check_github_status: "true"
           # This functionality is poorly implemented and has been
-          # causing a lot of problems due to the MITM implementation
-          # hogging or leaking memory, so we disable it for now.
-          monitor_permissions: "false"
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  If this happens to you just uncomment
+          # this line.
+          # monitor_permissions: "false"
           output_workflow_context: "true"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
@@ -84,9 +85,10 @@ jobs:
         uses: cisagov/action-job-preamble@v1
         with:
           # This functionality is poorly implemented and has been
-          # causing a lot of problems due to the MITM implementation
-          # hogging or leaking memory, so we disable it for now.
-          monitor_permissions: "false"
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  If this happens to you just uncomment
+          # this line.
+          # monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
           # configuration stored in the cisagov organization-level

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -29,9 +29,10 @@ jobs:
         with:
           check_github_status: "true"
           # This functionality is poorly implemented and has been
-          # causing a lot of problems due to the MITM implementation
-          # hogging or leaking memory, so we disable it for now.
-          monitor_permissions: "false"
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  If this happens to you just uncomment
+          # this line.
+          # monitor_permissions: "false"
           output_workflow_context: "true"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
@@ -60,9 +61,10 @@ jobs:
         uses: cisagov/action-job-preamble@v1
         with:
           # This functionality is poorly implemented and has been
-          # causing a lot of problems due to the MITM implementation
-          # hogging or leaking memory, so we disable it for now.
-          monitor_permissions: "false"
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  If this happens to you just uncomment
+          # this line.
+          # monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
           # configuration stored in the cisagov organization-level

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -25,9 +25,10 @@ jobs:
         with:
           check_github_status: "true"
           # This functionality is poorly implemented and has been
-          # causing a lot of problems due to the MITM implementation
-          # hogging or leaking memory, so we disable it for now.
-          monitor_permissions: "false"
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  If this happens to you just uncomment
+          # this line.
+          # monitor_permissions: "false"
           output_workflow_context: "true"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
@@ -57,9 +58,10 @@ jobs:
         uses: cisagov/action-job-preamble@v1
         with:
           # This functionality is poorly implemented and has been
-          # causing a lot of problems due to the MITM implementation
-          # hogging or leaking memory, so we disable it for now.
-          monitor_permissions: "false"
+          # causing problems due to the MITM implementation hogging or
+          # leaking memory.  If this happens to you just uncomment
+          # this line.
+          # monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
           # configuration stored in the cisagov organization-level


### PR DESCRIPTION
## 🗣 Description ##

Do not disable GitHub permissions monitoring by default, but do leave a commented-out line that can be uncommented to do so. The idea is that we should only comment out this functionality where we really must.

## 💭 Motivation and context ##

See @mcdonnnj's final review in cisagov/skeleton-generic#201.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.