### PR TITLE
Disable GitHub permissions monitoring everywhere

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           # you want to temporarily enable it, simply set
           # monitor_permissions equal to "true".
           #
-          # TODO: Re-anable this functionality when practical.  See
+          # TODO: Re-enable this functionality when practical.  See
           # cisagov/skeleton-generic#207 for more details.
           monitor_permissions: "false"
           output_workflow_context: "true"
@@ -81,7 +81,7 @@ jobs:
           # you want to temporarily enable it, simply set
           # monitor_permissions equal to "true".
           #
-          # TODO: Re-anable this functionality when practical.  See
+          # TODO: Re-enable this functionality when practical.  See
           # cisagov/skeleton-generic#207 for more details.
           monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,13 @@ jobs:
           check_github_status: "true"
           # This functionality is poorly implemented and has been
           # causing problems due to the MITM implementation hogging or
-          # leaking memory.  If this happens to you just uncomment
-          # this line.
-          # monitor_permissions: "false"
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-anable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
           output_workflow_context: "true"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
@@ -73,9 +77,13 @@ jobs:
         with:
           # This functionality is poorly implemented and has been
           # causing problems due to the MITM implementation hogging or
-          # leaking memory.  If this happens to you just uncomment
-          # this line.
-          # monitor_permissions: "false"
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-anable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
           # configuration stored in the cisagov organization-level

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
           # you want to temporarily enable it, simply set
           # monitor_permissions equal to "true".
           #
-          # TODO: Re-anable this functionality when practical.  See
+          # TODO: Re-enable this functionality when practical.  See
           # cisagov/skeleton-generic#207 for more details.
           monitor_permissions: "false"
           output_workflow_context: "true"
@@ -94,7 +94,7 @@ jobs:
           # you want to temporarily enable it, simply set
           # monitor_permissions equal to "true".
           #
-          # TODO: Re-anable this functionality when practical.  See
+          # TODO: Re-enable this functionality when practical.  See
           # cisagov/skeleton-generic#207 for more details.
           monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,9 +39,13 @@ jobs:
           check_github_status: "true"
           # This functionality is poorly implemented and has been
           # causing problems due to the MITM implementation hogging or
-          # leaking memory.  If this happens to you just uncomment
-          # this line.
-          # monitor_permissions: "false"
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-anable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
           output_workflow_context: "true"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
@@ -86,9 +90,13 @@ jobs:
         with:
           # This functionality is poorly implemented and has been
           # causing problems due to the MITM implementation hogging or
-          # leaking memory.  If this happens to you just uncomment
-          # this line.
-          # monitor_permissions: "false"
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-anable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
           # configuration stored in the cisagov organization-level

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,9 +30,13 @@ jobs:
           check_github_status: "true"
           # This functionality is poorly implemented and has been
           # causing problems due to the MITM implementation hogging or
-          # leaking memory.  If this happens to you just uncomment
-          # this line.
-          # monitor_permissions: "false"
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-anable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
           output_workflow_context: "true"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
@@ -62,9 +66,13 @@ jobs:
         with:
           # This functionality is poorly implemented and has been
           # causing problems due to the MITM implementation hogging or
-          # leaking memory.  If this happens to you just uncomment
-          # this line.
-          # monitor_permissions: "false"
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-anable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
           # configuration stored in the cisagov organization-level

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -70,7 +70,7 @@ jobs:
           # you want to temporarily enable it, simply set
           # monitor_permissions equal to "true".
           #
-          # TODO: Re-anable this functionality when practical.  See
+          # TODO: Re-enable this functionality when practical.  See
           # cisagov/skeleton-generic#207 for more details.
           monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -26,9 +26,13 @@ jobs:
           check_github_status: "true"
           # This functionality is poorly implemented and has been
           # causing problems due to the MITM implementation hogging or
-          # leaking memory.  If this happens to you just uncomment
-          # this line.
-          # monitor_permissions: "false"
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-anable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
           output_workflow_context: "true"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
@@ -59,9 +63,13 @@ jobs:
         with:
           # This functionality is poorly implemented and has been
           # causing problems due to the MITM implementation hogging or
-          # leaking memory.  If this happens to you just uncomment
-          # this line.
-          # monitor_permissions: "false"
+          # leaking memory.  As a result we disable it by default.  If
+          # you want to temporarily enable it, simply set
+          # monitor_permissions equal to "true".
+          #
+          # TODO: Re-anable this functionality when practical.  See
+          # cisagov/skeleton-generic#207 for more details.
+          monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring
           # configuration. By default this will yield the
           # configuration stored in the cisagov organization-level

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -30,7 +30,7 @@ jobs:
           # you want to temporarily enable it, simply set
           # monitor_permissions equal to "true".
           #
-          # TODO: Re-anable this functionality when practical.  See
+          # TODO: Re-enable this functionality when practical.  See
           # cisagov/skeleton-generic#207 for more details.
           monitor_permissions: "false"
           output_workflow_context: "true"
@@ -67,7 +67,7 @@ jobs:
           # you want to temporarily enable it, simply set
           # monitor_permissions equal to "true".
           #
-          # TODO: Re-anable this functionality when practical.  See
+          # TODO: Re-enable this functionality when practical.  See
           # cisagov/skeleton-generic#207 for more details.
           monitor_permissions: "false"
           # Use a variable to specify the permissions monitoring


### PR DESCRIPTION
## 🗣 Description ##

This pull request disables GitHub permissions monitoring everywhere.

This functionality should be re-enabled when practical.  See cisagov/skeleton-generic#207 for more details.

## 💭 Motivation and context ##

[This functionality](https://github.com/GitHubSecurityLab/actions-permissions/tree/main/monitor) is poorly implemented and has been causing workflows to unnecessarily fail due to the MITM implementation hogging or leaking memory.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.