### PR TITLE
Upgrade to the latest version of the `ansible-lint` `pre-commit` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -165,7 +165,7 @@ repos:
 
   # Ansible hooks
   - repo: https://github.com/ansible/ansible-lint
-    rev: v25.1.3
+    rev: v25.4.0
     hooks:
       - id: ansible-lint
         additional_dependencies:


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps the `ansible-lint` `pre-commit` hook to the latest version.

## 💭 Motivation and context ##

[Version 25.4.0 is the first version to support Fedora 42 in the Ansible YAML metadata schema](https://github.com/ansible/ansible-lint/releases/tag/v25.4.0), which is required for cisagov/skeleton-ansible-role#229.

See also cisagov/skeleton-ansible-role#229.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
