### PR TITLE
Adjust the logic used to check for GNU getopt in the `setup-env` script

### DIFF
--- a/setup-env
+++ b/setup-env
@@ -101,10 +101,10 @@ LONGOPTS="force,help,install-hooks,list-versions,python-version:,venv-name:"
 # Define short options for getopt
 SHORTOPTS="fhilp:v:"
 
-# Check for GNU getopt by matching a specific pattern ("getopt from util-linux")
-# in its version output. This approach presumes the output format remains stable.
-# Be aware that format changes could invalidate this check.
-if [[ $(getopt --version 2> /dev/null) != *"getopt from util-linux"* ]]; then
+# Check for GNU getopt by testing for long option support. GNU getopt supports
+# the "--test" option and will return exit code 4 while POSIX/BSD getopt does
+# not and will return exit code 0.
+if getopt --test > /dev/null 2>&1; then
   cat << 'END_OF_LINE'
 
   Please note, this script requires GNU getopt due to its enhanced


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the logic used to check for the presence of GNU getopt in the `setup-env` script.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This was mentioned by Copilot in https://github.com/cisagov/saver/pull/91#discussion_r2258251179 and seemed like a useful change to implement.

> [!NOTE]
> The implemented change is slightly different from the Copilot suggestion because a bash `if`/`then` is true on an exit code of 0. The Copilot suggestion is I think based on non-bash/shell environments where a 0 would be a false value.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that the new logic works as expected on my MacBook when testing against GNU getopt and the BSD version that comes on macOS by default.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
