### PR TITLE
Add more repository labels and expand the auto-labeling configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,6 +19,13 @@ dependencies:
           # Add any dependency files used.
           - .pre-commit-config.yaml
           - requirements*.txt
+# Enable if Docker is used in the repository.
+# docker:
+#   - changed-files:
+#       - any-glob-to-any-file:
+#           - "**/compose*.yml"
+#           - "**/docker-compose*.yml"
+#           - "**/Dockerfile*"
 documentation:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,6 +2,9 @@
 # Rather than breaking up descriptions into multiline strings we disable that
 # specific rule in yamllint for this file.
 # yamllint disable rule:line-length
+- color: f15a53
+  description: Pull requests that update Ansible code
+  name: ansible
 - color: eb6420
   description: This issue or pull request is awaiting the outcome of another issue or pull request
   name: blocked
@@ -17,6 +20,9 @@
 - color: 0366d6
   description: Pull requests that update a dependency file
   name: dependencies
+- color: 2497ed
+  description: Pull requests that update Docker code
+  name: docker
 - color: 5319e7
   description: This issue or pull request improves or adds to documentation
   name: documentation
@@ -50,12 +56,21 @@
 - color: fcdb45
   description: This pull request is awaiting an action or decision to move forward
   name: on hold
+- color: 02a8ef
+  description: Pull requests that update Packer code
+  name: packer
+- color: 3772a4
+  description: Pull requests that update Python code
+  name: python
 - color: ef476c
   description: This issue is a request for information or needs discussion
   name: question
 - color: d73a4a
   description: This issue or pull request addresses a security issue
   name: security
+- color: 7b42bc
+  description: Pull requests that update Terraform code
+  name: terraform
 - color: 00008b
   description: This issue or pull request adds or otherwise modifies test code
   name: test


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds five technology-specific labels to our default repository label configuration. It also adds a pull request labeling configuration for the `docker` tag.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We use these five tags across different skeleton types and I thought it might be good to just have them available everywhere for consistency. This would also match the auto-labeling configuration such that if a rule is enabled the label for it is available.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
