### PR TITLE
Enable all label configuration for `actions/labeler`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,24 +8,22 @@
 # crazy-max/ghaction-github-labeler configuration file located at
 # .github/labels.yml.
 
-# Enable if Ansible playbooks are used in the repository.
-# ansible:
-#   - changed-files:
-#       - any-glob-to-any-file:
-#           - "**/ansible/**"
+ansible:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/ansible/**"
 dependencies:
   - changed-files:
       - any-glob-to-any-file:
           # Add any dependency files used.
           - .pre-commit-config.yaml
           - requirements*.txt
-# Enable if Docker is used in the repository.
-# docker:
-#   - changed-files:
-#       - any-glob-to-any-file:
-#           - "**/compose*.yml"
-#           - "**/docker-compose*.yml"
-#           - "**/Dockerfile*"
+docker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/compose*.yml"
+          - "**/docker-compose*.yml"
+          - "**/Dockerfile*"
 documentation:
   - changed-files:
       - any-glob-to-any-file:
@@ -34,21 +32,18 @@ github-actions:
   - changed-files:
       - any-glob-to-any-file:
           - .github/workflows/**
-# Enable if Packer is used in the repository.
-# packer:
-#   - changed-files:
-#       - any-glob-to-any-file:
-#           - "**/*.pkr.hcl"
-# Enable if Python is used in the repository.
-# python:
-#   - changed-files:
-#       - any-glob-to-any-file:
-#           - "**/*.py"
-# Enable if Terraform is used in the repository.
-# terraform:
-#   - changed-files:
-#       - any-glob-to-any-file:
-#           - "**/*.tf"
+packer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.pkr.hcl"
+python:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.py"
+terraform:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.tf"
 test:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request enables all label configurations in the configuration file for [actions/labeler] by default.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

With the merge of #222, any label configured for [actions/labeler] is defined in the configuration for [crazy-max/ghaction-github-labeler]. That means there should be no issue with enabling these labels for application.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[actions/labeler]: https://github.com/actions/labeler
[crazy-max/ghaction-github-labeler]: https://github.com/crazy-max/ghaction-github-labeler
