### PR TITLE
Add JavaScript-related labels with labeling support

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,6 +32,10 @@ github-actions:
   - changed-files:
       - any-glob-to-any-file:
           - .github/workflows/**
+javascript:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.js"
 packer:
   - changed-files:
       - any-glob-to-any-file:
@@ -54,6 +58,10 @@ test:
           - .isort.cfg
           - .mdl_config.yaml
           - .yamllint
+typescript:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.ts"
 upstream update:
   - head-branch:
       # Any Lineage pull requests should use this branch.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -47,6 +47,9 @@
 - color: fef2c0
   description: This issue or pull request is not applicable, incorrect, or obsolete
   name: invalid
+- color: f1d642
+  description: Pull requests that update JavaScript code
+  name: javascript
 - color: ce099a
   description: This pull request is ready to merge during the next Lineage Kraken release
   name: kraken 🐙
@@ -74,6 +77,9 @@
 - color: 00008b
   description: This issue or pull request adds or otherwise modifies test code
   name: test
+- color: 2b6ebf
+  description: Pull requests that update TypeScript code
+  name: typescript
 - color: 1d76db
   description: This issue or pull request pulls in upstream updates
   name: upstream update


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds `javascript` and `typescript` labels to the configuration for [crazy-max/ghaction-github-labeler](https://github.com/crazy-max/ghaction-github-labeler] as well as updating the configuration for [actions/labeler](https://github.com/actions/labeler) to use the new labels.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Since there are some downstream repositories that use JavaScript and/or TypeScript it makes sense to have suitable labels availabe with matching rules for auto-labeling pull requests.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
