### PR TITLE
Add a label and auto-label configuration for shell scripts

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -44,6 +44,13 @@ python:
   - changed-files:
       - any-glob-to-any-file:
           - "**/*.py"
+shell script:
+  - changed-files:
+      - any-glob-to-any-file:
+          # Add any shell scripts that do not end in the ".sh" extension.
+          - "**/*.sh"
+          - bump-version
+          - setup-env
 terraform:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,7 +47,8 @@ python:
 shell script:
   - changed-files:
       - any-glob-to-any-file:
-          # Add any shell scripts that do not end in the ".sh" extension.
+          # If this project has any shell scripts that do not end in the ".sh"
+          # extension, add them below.
           - "**/*.sh"
           - bump-version
           - setup-env

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -71,6 +71,9 @@
 - color: d73a4a
   description: This issue or pull request addresses a security issue
   name: security
+- color: 4eaa25
+  description: Pull requests that update shell scripts
+  name: shell script
 - color: 7b42bc
   description: Pull requests that update Terraform code
   name: terraform


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a label and [actions/labeler](https://github.com/actions/labeler) configuration to automatically label shell scripts.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Since we use shell scripts throughout our projects it makes sense to have a dedicated label.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that the dry run would create the new label.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
