### PR TITLE
Update `bandit` `pre-commit` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,7 +129,7 @@ repos:
 
   # Python hooks
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.9.0
+    rev: 1.9.1
     hooks:
       - id: bandit
   - repo: https://github.com/psf/black-pre-commit-mirror


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the `bandit` `pre-commit` hook from version 1.9.0 to version 1.9.1.

## 💭 Motivation and context ##

The 1.9.0 release of `bandit` was flawed due to a failure of the GitHub Actions workflows that publish to PyPI and Test PyPI.  The 1.9.1 release resolved the issue.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.