### PR TITLE
Revert "Move all Python tool configs to `pyproject.toml`"

### DIFF
--- a/.bandit.yml
+++ b/.bandit.yml
@@ -1,0 +1,13 @@
+---
+# Configuration file for the Bandit python security scanner
+# https://bandit.readthedocs.io/en/latest/config.html
+
+# Tests are first included by `tests`, and then excluded by `skips`.
+# If `tests` is empty, all tests are considered included.
+
+tests:
+# - B101
+# - B102
+
+skips:
+# - B101 # skip "assert used" check since assertions are required in pytests

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
-[tool.flake8]
+[flake8]
 max-line-length = 80
 # Select (turn on)
 # * Complexity violations reported by mccabe (C) -
@@ -13,7 +13,7 @@ max-line-length = 80
 #   https://github.com/PyCQA/flake8-bugbear#list-of-warnings
 # * The B950 flake8-bugbear opinionated warning -
 #   https://github.com/PyCQA/flake8-bugbear#opinionated-warnings
-select = ["C", "D", "E", "F", "W", "B", "B950"]
+select = C,D,E,F,W,B,B950
 # Ignore flake8's default warning about maximum line length, which has
 # a hard stop at the configured value.  Instead we use
 # flake8-bugbear's B950, which allows up to 10% overage.
@@ -22,16 +22,4 @@ select = ["C", "D", "E", "F", "W", "B", "B950"]
 # operators.  It no longer agrees with PEP8.  See, for example, here:
 # https://github.com/ambv/black/issues/21. Guido agrees here:
 # https://github.com/python/peps/commit/c59c4376ad233a62ca4b3a6060c81368bd21e85b.
-extend-ignore = ["E501", "W503"]
-
-[tool.isort]
-combine_star = true
-force_sort_within_sections = true
-
-import_heading_stdlib = "Standard Python Libraries"
-import_heading_thirdparty = "Third-Party Libraries"
-import_heading_firstparty = "cisagov Libraries"
-
-# Run isort under the black profile to align with our other Python
-# linting
-profile = "black"
+ignore = E501,W503

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -61,9 +61,11 @@ test:
       - any-glob-to-any-file:
           # Add any test-related files or paths.
           - .ansible-lint
+          - .bandit.yml
+          - .flake8
+          - .isort.cfg
           - .mdl_config.yaml
           - .yamllint
-          - pyproject.toml
 typescript:
   - changed-files:
       - any-glob-to-any-file:

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,10 @@
+[settings]
+combine_star=true
+force_sort_within_sections=true
+
+import_heading_stdlib=Standard Python Libraries
+import_heading_thirdparty=Third-Party Libraries
+import_heading_firstparty=cisagov Libraries
+
+# Run isort under the black profile to align with our other Python linting
+profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,6 +132,8 @@ repos:
     rev: 1.9.1
     hooks:
       - id: bandit
+        args:
+          - --config=.bandit.yml
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 25.11.0
     hooks:
@@ -142,9 +144,6 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-docstrings==1.7.0
-          # This is necessary to read the flake8 configuration from
-          # the pyproject.toml file.
-          - flake8-pyproject==1.2.3
   - repo: https://github.com/PyCQA/isort
     rev: 7.0.0
     hooks:


### PR DESCRIPTION
Reverts cisagov/skeleton-generic#235.

See the discussion in #234 for more details.