### PR TITLE
Upgrade the `ansible-lint` `pre-commit` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -171,7 +171,7 @@ repos:
 
   # Ansible hooks
   - repo: https://github.com/ansible/ansible-lint
-    rev: v25.11.0
+    rev: v25.11.1
     hooks:
       - id: ansible-lint
         additional_dependencies:


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades the `ansible-lint` `pre-commit` hook to the latest version.

## 💭 Motivation and context ##

The [`v25.11.1` release](https://github.com/ansible/ansible-lint/releases/tag/v25.11.1) is necessary for cisagov/skeleton-ansible-role#243 (Fedora 43 support).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.