### PR TITLE
Add `--py310-plus` argument to `pyupgrade` `pre-commit` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -168,6 +168,12 @@ repos:
     rev: v3.21.1
     hooks:
       - id: pyupgrade
+        args:
+          # Python 3.10 is currently the oldest non-EOL version of
+          # Python, so we want to apply all rules that apply to this
+          # version or later.  See here for more details:
+          # https://www.gyford.com/phil/writing/2025/08/26/how-to-use-pyupgrade/
+          - --py310-plus
 
   # Ansible hooks
   - repo: https://github.com/ansible/ansible-lint


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds an argument to `pyupgrade` to apply all changes compatible with Python 3.10 and later.

## 💭 Motivation and context ##

Python 3.10 is currently the oldest non-EOL version of Python, so we want to [apply all rules that apply to this version or later](https://www.gyford.com/phil/writing/2025/08/26/how-to-use-pyupgrade/).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.