### PR TITLE
Pin `ansible-core` to 2.17.7 or later

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -187,22 +187,7 @@ repos:
           # hook identifies a vulnerability in ansible-core 2.16.13,
           # but all versions of ansible 9 have a dependency on
           # ~=2.16.X.
-          #
-          # It is also a good idea to go ahead and upgrade to version
-          # 10 since version 9 is going EOL at the end of November:
-          # https://endoflife.date/ansible
           # - ansible>=10,<11
-          # ansible-core 2.16.3 through 2.16.6 suffer from the bug
-          # discussed in ansible/ansible#82702, which breaks any
-          # symlinked files in vars, tasks, etc. for any Ansible role
-          # installed via ansible-galaxy.  Hence we never want to
-          # install those versions.
-          #
-          # Note that the pip-audit pre-commit hook identifies a
-          # vulnerability in ansible-core 2.16.13.  The pin of
-          # ansible-core to >=2.17 effectively also pins ansible to
-          # >=10.
-          #
           # It is also a good idea to go ahead and upgrade to
           # ansible-core 2.17 since security support for ansible-core
           # 2.16 ends this month:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -188,15 +188,12 @@ repos:
           # but all versions of ansible 9 have a dependency on
           # ~=2.16.X.
           # - ansible>=10,<11
-          # It is also a good idea to go ahead and upgrade to
-          # ansible-core 2.17 since security support for ansible-core
-          # 2.16 ends this month:
-          # https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
+          # ansible-core<2.17.7 suffers from GHSA-99w6-3xph-cx78.
           #
           # Note that any changes made to this dependency must also be
           # made in requirements.txt in cisagov/skeleton-packer and
           # requirements-test.txt in cisagov/skeleton-ansible-role.
-          - ansible-core>=2.17
+          - ansible-core>=2.17.7
 
   # Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the pin on `ansible-core` to 2.17.7 or later.

## 💭 Motivation and context ##


`ansible-core<2.17.7` suffers from [GHSA-99w6-3xph-cx78](https://github.com/advisories/GHSA-99w6-3xph-cx78).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.