### PR TITLE
Remove installation of `wheel` Python package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,7 @@ jobs:
           -o $(go env GOPATH)/bin/terraform-docs
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip setuptools
           pip install --upgrade --requirement requirements-test.txt
       - name: Set up pre-commit hook environments
         run: pre-commit install-hooks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-setuptools
-wheel
+setuptools>=70.1

--- a/setup-env
+++ b/setup-env
@@ -271,7 +271,7 @@ fi
 pyenv local "${env_name}"
 
 # Upgrade pip and friends
-python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install --upgrade pip setuptools
 
 # Find a requirements file (if possible) and install
 for req_file in "requirements-dev.txt" "requirements-test.txt" "requirements.txt"; do


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes installations of the `wheel` Python package, particularly when it is installed alongside `setuptools`.

## 💭 Motivation and context ##

It is [no longer necessary](https://github.com/pypa/wheel?tab=readme-ov-file#historical-note) to install `wheel` alongside `setuptools` as of `setuptools` v70.1.

Resolves #248.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.