### PR TITLE
Add additional plugins to the `flake8` pre-commit configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,8 @@ max-line-length = 80
 # Select (turn on)
 # * Complexity violations reported by mccabe (C) -
 #   http://flake8.pycqa.org/en/latest/user/error-codes.html#error-violation-codes
+# * Default errors and warnings reported by flake8-comprehensions (C4) -
+#   https://github.com/adamchainz/flake8-comprehensions#rules
 # * Documentation conventions compliance reported by pydocstyle (D) -
 #   http://www.pydocstyle.org/en/stable/error_codes.html
 # * Default errors and warnings reported by dlint (DUO) -
@@ -20,7 +22,7 @@ max-line-length = 80
 #   https://github.com/PyCQA/flake8-bugbear#list-of-warnings
 # * The B950 flake8-bugbear opinionated warning -
 #   https://github.com/PyCQA/flake8-bugbear#opinionated-warnings
-select = C,D,DUO,E,F,N,NQA,W,B,B950
+select = C,C4,D,DUO,E,F,N,NQA,W,B,B950
 
 # Ignore
 # * flake8's default warning about whitespace before ':' because Black enforces

--- a/.flake8
+++ b/.flake8
@@ -2,35 +2,37 @@
 max-line-length = 80
 
 # Select (turn on)
-# * Complexity violations reported by mccabe (C) -
+# * C: Complexity violations reported by mccabe -
 #   http://flake8.pycqa.org/en/latest/user/error-codes.html#error-violation-codes
-# * Default errors and warnings reported by flake8-comprehensions (C4) -
+# * C4: Default errors and warnings reported by flake8-comprehensions -
 #   https://github.com/adamchainz/flake8-comprehensions#rules
-# * Documentation conventions compliance reported by pydocstyle (D) -
+# * D: Documentation conventions compliance reported by pydocstyle -
 #   http://www.pydocstyle.org/en/stable/error_codes.html
-# * Default errors and warnings reported by dlint (DUO) -
+# * DUO: Default errors and warnings reported by dlint -
 #   https://github.com/dlint-py/dlint/tree/master/docs
-# * Default errors and warnings reported by pycodestyle (E and W) -
+# * E: Default errors reported by pycodestyle -
 #   https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
-# * Default errors reported by pyflakes (F) -
+# * F: Default errors reported by pyflakes -
 #   http://flake8.pycqa.org/en/latest/glossary.html#term-pyflakes
-# * Default errors and warnings reported by pep8-naming (N) -
+# * N: Default errors and warnings reported by pep8-naming -
 #   https://github.com/PyCQA/pep8-naming#error-codes
-# * Default errors and warnings reported by flake8-noqa (NQA) -
+# * NQA: Default errors and warnings reported by flake8-noqa -
 #   https://github.com/plinss/flake8-noqa#error-codes
-# * Default warnings reported by flake8-bugbear (B) -
+# * W: Default warnings reported by pycodestyle -
+#   https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
+# * B: Default warnings reported by flake8-bugbear -
 #   https://github.com/PyCQA/flake8-bugbear#list-of-warnings
-# * The B950 flake8-bugbear opinionated warning -
+# * B950: Bugbear opinionated warning for line too long -
 #   https://github.com/PyCQA/flake8-bugbear#opinionated-warnings
 select = C,C4,D,DUO,E,F,N,NQA,W,B,B950
 
 # Ignore
-# * flake8's default warning about whitespace before ':' because Black enforces
+# * E203: flake8's default warning about whitespace before ':' because Black enforces
 #   an equal amount of whitespace around slice operators (':').
-# * flake8's default warning about maximum line length, which has a hard stop
+# * E501: flake8's default warning about maximum line length, which has a hard stop
 #   at the configured value.  Instead we use flake8-bugbear's B950, which
 #   allows up to 10% overage.
-# * flake8's warning about line breaks before binary operators.  It no longer
+# * W503: flake8's warning about line breaks before binary operators.  It no longer
 #   agrees with PEP8.  See, for example, here:
 #   https://github.com/ambv/black/issues/21
 #   Guido agrees here:

--- a/.flake8
+++ b/.flake8
@@ -6,6 +6,8 @@ max-line-length = 80
 #   http://flake8.pycqa.org/en/latest/user/error-codes.html#error-violation-codes
 # * Documentation conventions compliance reported by pydocstyle (D) -
 #   http://www.pydocstyle.org/en/stable/error_codes.html
+# * Default errors and warnings reported by dlint (DUO) -
+#   https://github.com/dlint-py/dlint/tree/master/docs
 # * Default errors and warnings reported by pycodestyle (E and W) -
 #   https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
 # * Default errors reported by pyflakes (F) -
@@ -14,7 +16,7 @@ max-line-length = 80
 #   https://github.com/PyCQA/flake8-bugbear#list-of-warnings
 # * The B950 flake8-bugbear opinionated warning -
 #   https://github.com/PyCQA/flake8-bugbear#opinionated-warnings
-select = C,D,E,F,W,B,B950
+select = C,D,DUO,E,F,W,B,B950
 
 # Ignore
 # * flake8's default warning about whitespace before ':' because Black enforces

--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,7 @@ max-line-length = 80
 # * C4: Default errors and warnings reported by flake8-comprehensions -
 #   https://github.com/adamchainz/flake8-comprehensions#rules
 # * D: Documentation conventions compliance reported by pydocstyle -
-#   http://www.pydocstyle.org/en/stable/error_codes.html
+#   https://github.com/PyCQA/pydocstyle/blob/master/docs/error_codes.rst
 # * DUO: Default errors and warnings reported by dlint -
 #   https://github.com/dlint-py/dlint/tree/master/docs
 # * E: Default errors reported by pycodestyle -

--- a/.flake8
+++ b/.flake8
@@ -12,13 +12,15 @@ max-line-length = 80
 #   https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
 # * Default errors reported by pyflakes (F) -
 #   http://flake8.pycqa.org/en/latest/glossary.html#term-pyflakes
+# * Default errors and warnings reported by pep8-naming (N) -
+#   https://github.com/PyCQA/pep8-naming#error-codes
 # * Default errors and warnings reported by flake8-noqa (NQA) -
 #   https://github.com/plinss/flake8-noqa#error-codes
 # * Default warnings reported by flake8-bugbear (B) -
 #   https://github.com/PyCQA/flake8-bugbear#list-of-warnings
 # * The B950 flake8-bugbear opinionated warning -
 #   https://github.com/PyCQA/flake8-bugbear#opinionated-warnings
-select = C,D,DUO,E,F,NQA,W,B,B950
+select = C,D,DUO,E,F,N,NQA,W,B,B950
 
 # Ignore
 # * flake8's default warning about whitespace before ':' because Black enforces

--- a/.flake8
+++ b/.flake8
@@ -3,7 +3,7 @@ max-line-length = 80
 
 # Select (turn on)
 # * C: Complexity violations reported by mccabe -
-#   http://flake8.pycqa.org/en/latest/user/error-codes.html#error-violation-codes
+#   https://flake8.pycqa.org/en/latest/user/error-codes.html#error-violation-codes
 # * C4: Default errors and warnings reported by flake8-comprehensions -
 #   https://github.com/adamchainz/flake8-comprehensions#rules
 # * D: Documentation conventions compliance reported by pydocstyle -
@@ -13,7 +13,7 @@ max-line-length = 80
 # * E: Default errors reported by pycodestyle -
 #   https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
 # * F: Default errors reported by pyflakes -
-#   http://flake8.pycqa.org/en/latest/glossary.html#term-pyflakes
+#   https://flake8.pycqa.org/en/latest/glossary.html#term-pyflakes
 # * N: Default errors and warnings reported by pep8-naming -
 #   https://github.com/PyCQA/pep8-naming#error-codes
 # * NQA: Default errors and warnings reported by flake8-noqa -

--- a/.flake8
+++ b/.flake8
@@ -14,6 +14,9 @@ max-line-length = 80
 # * The B950 flake8-bugbear opinionated warning -
 #   https://github.com/PyCQA/flake8-bugbear#opinionated-warnings
 select = C,D,E,F,W,B,B950
+# Ignore flake8's default warning about whitespace before ':' because Black
+# enforces an equal amount of whitespace around slice operators (':').
+#
 # Ignore flake8's default warning about maximum line length, which has
 # a hard stop at the configured value.  Instead we use
 # flake8-bugbear's B950, which allows up to 10% overage.
@@ -22,4 +25,4 @@ select = C,D,E,F,W,B,B950
 # operators.  It no longer agrees with PEP8.  See, for example, here:
 # https://github.com/ambv/black/issues/21. Guido agrees here:
 # https://github.com/python/peps/commit/c59c4376ad233a62ca4b3a6060c81368bd21e85b.
-ignore = E501,W503
+ignore = E203,E501,W503

--- a/.flake8
+++ b/.flake8
@@ -27,12 +27,12 @@ max-line-length = 80
 select = C,C4,D,DUO,E,F,N,NQA,W,B,B950
 
 # Ignore
-# * E203: flake8's default warning about whitespace before ':' because Black enforces
+# * E203: pycodestyle's default warning about whitespace before ':' because Black enforces
 #   an equal amount of whitespace around slice operators (':').
-# * E501: flake8's default warning about maximum line length, which has a hard stop
+# * E501: pycodestyle's default warning about maximum line length, which has a hard stop
 #   at the configured value.  Instead we use flake8-bugbear's B950, which
 #   allows up to 10% overage.
-# * W503: flake8's warning about line breaks before binary operators.  It no longer
+# * W503: pycodestyle's warning about line breaks before binary operators.  It no longer
 #   agrees with PEP8.  See, for example, here:
 #   https://github.com/ambv/black/issues/21
 #   Guido agrees here:

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 80
+
 # Select (turn on)
 # * Complexity violations reported by mccabe (C) -
 #   http://flake8.pycqa.org/en/latest/user/error-codes.html#error-violation-codes
@@ -14,15 +15,16 @@ max-line-length = 80
 # * The B950 flake8-bugbear opinionated warning -
 #   https://github.com/PyCQA/flake8-bugbear#opinionated-warnings
 select = C,D,E,F,W,B,B950
-# Ignore flake8's default warning about whitespace before ':' because Black
-# enforces an equal amount of whitespace around slice operators (':').
-#
-# Ignore flake8's default warning about maximum line length, which has
-# a hard stop at the configured value.  Instead we use
-# flake8-bugbear's B950, which allows up to 10% overage.
-#
-# Also ignore flake8's warning about line breaks before binary
-# operators.  It no longer agrees with PEP8.  See, for example, here:
-# https://github.com/ambv/black/issues/21. Guido agrees here:
-# https://github.com/python/peps/commit/c59c4376ad233a62ca4b3a6060c81368bd21e85b.
+
+# Ignore
+# * flake8's default warning about whitespace before ':' because Black enforces
+#   an equal amount of whitespace around slice operators (':').
+# * flake8's default warning about maximum line length, which has a hard stop
+#   at the configured value.  Instead we use flake8-bugbear's B950, which
+#   allows up to 10% overage.
+# * flake8's warning about line breaks before binary operators.  It no longer
+#   agrees with PEP8.  See, for example, here:
+#   https://github.com/ambv/black/issues/21
+#   Guido agrees here:
+#   https://github.com/python/peps/commit/c59c4376ad233a62ca4b3a6060c81368bd21e85b
 ignore = E203,E501,W503

--- a/.flake8
+++ b/.flake8
@@ -12,11 +12,13 @@ max-line-length = 80
 #   https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
 # * Default errors reported by pyflakes (F) -
 #   http://flake8.pycqa.org/en/latest/glossary.html#term-pyflakes
+# * Default errors and warnings reported by flake8-noqa (NQA) -
+#   https://github.com/plinss/flake8-noqa#error-codes
 # * Default warnings reported by flake8-bugbear (B) -
 #   https://github.com/PyCQA/flake8-bugbear#list-of-warnings
 # * The B950 flake8-bugbear opinionated warning -
 #   https://github.com/PyCQA/flake8-bugbear#opinionated-warnings
-select = C,D,DUO,E,F,W,B,B950
+select = C,D,DUO,E,F,NQA,W,B,B950
 
 # Ignore
 # * flake8's default warning about whitespace before ':' because Black enforces

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,6 +143,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
+          - flake8-bugbear==25.11.29
           - flake8-docstrings==1.7.0
   - repo: https://github.com/PyCQA/isort
     rev: 8.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,6 +145,7 @@ repos:
         additional_dependencies:
           - dlint==0.16.0
           - flake8-bugbear==25.11.29
+          - flake8-comprehensions==3.17.0
           - flake8-docstrings==1.7.0
           - flake8-noqa==1.5.0
           - pep8-naming==0.15.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,6 +143,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
+          - dlint==0.16.0
           - flake8-bugbear==25.11.29
           - flake8-docstrings==1.7.0
   - repo: https://github.com/PyCQA/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,6 +147,7 @@ repos:
           - flake8-bugbear==25.11.29
           - flake8-docstrings==1.7.0
           - flake8-noqa==1.5.0
+          - pep8-naming==0.15.1
   - repo: https://github.com/PyCQA/isort
     rev: 8.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,6 +146,7 @@ repos:
           - dlint==0.16.0
           - flake8-bugbear==25.11.29
           - flake8-docstrings==1.7.0
+          - flake8-noqa==1.5.0
   - repo: https://github.com/PyCQA/isort
     rev: 8.0.0
     hooks:


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds the following plugins to the [flake8] pre-commit hook's configuration (with version pins corresponding to the latest releases):
- [dlint]: Security focused static analysis.
- [flake8-bugbear]: Opinionated linting from PyCQA (note that we already had the rules enabled in our configuration).
- [flake8-comprehensions]: Flags for better use of comprehensions.
- [flake8-noqa]: Validate `# noqa` comments.
- [pep8-naming]: Check that code complies with the [PEP 8 naming conventions](https://peps.python.org/pep-0008/#naming-conventions).

The configuration file is updated to use these new plugins. I also updated the ignore comment block in the configuration file to follow the style of the select comment block. Lastly both select and ignore comment blocks were adjusted so the lint prefixes were the first thing for each description to improve at-a-glance reading.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I thought it worthwhile to leverage some of the [flake8] plugins out there to improve our Python code linting.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified this updated configuration runs without problems in [cisagov/skeleton-python-library](https://github.com/cisagov/skeleton-python-library).
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[dlint]: https://github.com/dlint-py/dlint
[flake8]: https://github.com/PyCQA/flake8
[flake8-bugbear]: https://github.com/PyCQA/flake8-bugbear
[flake8-comprehensions]: https://github.com/adamchainz/flake8-comprehensions
[flake8-noqa]: https://github.com/plinss/flake8-noqa
[pep8-naming]: https://github.com/PyCQA/pep8-naming
