### PR TITLE
Add a pre-commit hook to lock Terraform providers automatically

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -207,6 +207,15 @@ repos:
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
+      # This needs to run after the terraform_validate hook so that any Terraform
+      # configurations are initialized.
+      - id: terraform_providers_lock
+        args:
+          - --args=-platform=darwin_amd64
+          - --args=-platform=darwin_arm64
+          - --args=-platform=linux_amd64
+          - --args=-platform=linux_arm64
+          - --hook-config=--mode=always-regenerate-lockfile
 
   # Docker hooks
   - repo: https://github.com/IamTheFij/docker-pre-commit


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a new pre-commit hook from the [antonbabenko/pre-commit-terraform](https://github.com/antonbabenko/pre-commit-terraform) collection we already use.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This new hook will ensure that any Terraform lock files contains hashes for all of our supported platforms (macOS/Linux on AMD64/ARM64). This will allow dependabot updates to cover all of our supported platforms and will ensure that manual updates will cover those same platforms.

> [!NOTE]
> I chose the `always-regenerate-lockfile` mode over `regenerate-lockfile-if-some-platform-missed` because the latter only checks hash counts and does not verify platforms. This does result in the downside that the hook will always download providers to acquire checksums.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I used the updated `.pre-commit-config.yaml` file in the [`first-commits` branch of cisagov/skeleton-tf-root-module](https://github.com/cisagov/skeleton-tf-root-module/pull/39) and this was the output:
```log
Lock terraform provider versions.........................................Failed
- hook id: terraform_providers_lock
- files were modified by this hook

- Fetching hashicorp/aws 6.15.0 for darwin_amd64...
- Retrieved hashicorp/aws 6.15.0 for darwin_amd64 (signed by HashiCorp)
- Fetching hashicorp/aws 6.15.0 for darwin_arm64...
- Retrieved hashicorp/aws 6.15.0 for darwin_arm64 (signed by HashiCorp)
- Fetching hashicorp/aws 6.15.0 for linux_amd64...
- Retrieved hashicorp/aws 6.15.0 for linux_amd64 (signed by HashiCorp)
- Fetching hashicorp/aws 6.15.0 for linux_arm64...
- Retrieved hashicorp/aws 6.15.0 for linux_arm64 (signed by HashiCorp)
- Obtained hashicorp/aws checksums for darwin_arm64; Additional checksums for this platform are now tracked in the lock file
- Obtained hashicorp/aws checksums for linux_amd64; All checksums for this platform were already tracked in the lock file
- Obtained hashicorp/aws checksums for linux_arm64; Additional checksums for this platform are now tracked in the lock file
- Obtained hashicorp/aws checksums for darwin_amd64; Additional checksums for this platform are now tracked in the lock file

Success! Terraform has updated the lock file.

Review the changes in .terraform.lock.hcl and then commit to your
version control system to retain the new checksums.
```

This is in line with what I'd expect from this pre-commit configuration and originally generating the lock file on a Linux AMD64 platform.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
