### PR TITLE
Ignore a vulnerability originating from `pygments`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -170,7 +170,7 @@ repos:
           # - https://github.com/pygments/pygments/issues/3058
           #
           # TODO: Remove this when it becomes possible.  See
-          # cisagov/skeleton-docker#285 for more details.
+          # cisagov/skeleton-generic#257 for more details.
           - --ignore-vuln
           - CVE-2026-4539
           # Add any pip requirements files to scan

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,6 +157,22 @@ repos:
     hooks:
       - id: pip-audit
         args:
+          # We have to ignore this vulnerability for now since an
+          # update for pygments has not yet been released.
+          #
+          # In any event, this vulnerability is unlikely to cause us
+          # any problems since we don't feed any regexes to pygments
+          # directly.  pygments is pulled in as a dependency of
+          # pytest.
+          #
+          # See also:
+          # - https://nvd.nist.gov/vuln/detail/CVE-2026-4539
+          # - https://github.com/pygments/pygments/issues/3058
+          #
+          # TODO: Remove this when it becomes possible.  See
+          # cisagov/skeleton-docker#285 for more details.
+          - --ignore-vuln
+          - CVE-2026-4539
           # Add any pip requirements files to scan
           - --requirement
           - requirements-dev.txt


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the `pre-commit` configuration for `pip-audit` to ignore a CVE originating from `pygments`.

See also:
- cisagov/skeleton-generic#257
- [CVE-2026-4539](https://nvd.nist.gov/vuln/detail/CVE-2026-4539)
- pygments/pygments#3058

## 💭 Motivation and context ##

We have to ignore this vulnerability for now since an update for `pygments` has not yet been released.

In any event, this vulnerability is unlikely to cause us any problems since we don't feed any regexes to `pygments` directly.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.