### PR TITLE
Stop ignoring `pygments` vulnerability

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,22 +160,6 @@ repos:
     hooks:
       - id: pip-audit
         args:
-          # We have to ignore this vulnerability for now since an
-          # update for pygments has not yet been released.
-          #
-          # In any event, this vulnerability is unlikely to cause us
-          # any problems since we don't feed any regexes to pygments
-          # directly.  pygments is pulled in as a dependency of
-          # pytest.
-          #
-          # See also:
-          # - https://nvd.nist.gov/vuln/detail/CVE-2026-4539
-          # - https://github.com/pygments/pygments/issues/3058
-          #
-          # TODO: Remove this when it becomes possible.  See
-          # cisagov/skeleton-generic#257 for more details.
-          - --ignore-vuln
-          - CVE-2026-4539
           # Add any pip requirements files to scan
           - --requirement
           - requirements-dev.txt


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `pre-commit` configuration for the `pip-audit` hook to stop ignoring a `pygments`-specific vulnerability (CVE-2026-4539).

## 💭 Motivation and context ##

Ignoring the vulnerability is no longer necessary now that [`pygments` 2.20.0 has been released](https://github.com/pygments/pygments/releases/tag/2.20.0).

Resolves cisagov/skeleton-generic#257.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.