### PR TITLE
Add a commented-out `exclude` for `Pipfile.lock` to the `pretty-format-json` `pre-commit` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,8 @@ repos:
       - id: pretty-format-json
         args:
           - --autofix
+        # Exclude all Pipfile.lock files
+        # exclude: .*/Pipfile\.lock$
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a commented-out `exclude` to the `pre-commit` configuration to exclude `Pipfile.lock` from the `pretty-format-json` hook.

## 💭 Motivation and context ##

This `exclude` directive will be uncommented in multiple downstream repos that use `pipenv`.  We simply let `pipenv` format those files however it wants; we don't care about prettifying them since they are for the most part only read by machines.

This also saves us some time and effort on Dependabot PRs that update the `Pipfile.lock` file since they should pass the `pre-commit` linters without being reformatted.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.