### PR TITLE
Explain why we include a lower bound pin for setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+# With setuptools 70.1 and later it is no longer necessary to install
+# wheel alongside setuptools.
 setuptools>=70.1


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a comment explaining why we use a lower bound pin for `setuptools`.

## 💭 Motivation and context ##

This should have been done in #249 but was not.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
