### PR TITLE
Use official `terraform-docs` releases again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,6 @@ env:
   PIP_CACHE_DIR: ~/.cache/pip
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
-  TERRAFORM_DOCS_REPO_BRANCH_NAME: cisagov
-  TERRAFORM_DOCS_REPO_DEPTH: 1
-  TERRAFORM_DOCS_REPO_URL: https://github.com/mcdonnnj/terraform-docs.git
 
 jobs:
   diagnostics:
@@ -172,26 +169,11 @@ jobs:
           PACKAGE_URL: honnef.co/go/tools/cmd/staticcheck
           PACKAGE_VERSION: ${{ steps.setup-env.outputs.staticcheck-version }}
         run: go install ${PACKAGE_URL}@${PACKAGE_VERSION}
-      # TODO: https://github.com/cisagov/skeleton-generic/issues/165
-      # We are temporarily using a branch of @mcdonnnj's fork of terraform-docs that
-      # groups changes from his PRs until they are approved and merged:
-      # https://github.com/terraform-docs/terraform-docs/pull/745
-      # https://github.com/terraform-docs/terraform-docs/pull/901
-      # This temporary fix will allow for ATX header support when terraform-docs is run
-      # during linting and output delimiter rows with cell spacing that passes
-      # Markdownlint's MD060/table-column-style rule.
-      - name: Clone ATX headers branch from terraform-docs fork
-        run: |
-          git clone \
-           --branch $TERRAFORM_DOCS_REPO_BRANCH_NAME \
-           --depth $TERRAFORM_DOCS_REPO_DEPTH \
-           --single-branch \
-           $TERRAFORM_DOCS_REPO_URL /tmp/terraform-docs
-      - name: Build and install terraform-docs binary
-        run: |
-          go build \
-          -C /tmp/terraform-docs \
-          -o $(go env GOPATH)/bin/terraform-docs
+      - name: Install terraform-docs
+        env:
+          PACKAGE_URL: github.com/terraform-docs/terraform-docs
+          PACKAGE_VERSION: ${{ steps.setup-env.outputs.terraform-docs-version }}
+        run: go install ${PACKAGE_URL}@${PACKAGE_VERSION}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request restores using official [terraform-docs] releases in the `build` workflow. This resolves #165.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

With the merge of my two feature branches into the [terraform-docs] repository and the new [`0.22.0` release](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.22.0) we can start using official releases again.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[terraform-docs]: https://github.com/terraform-docs/terraform-docs
