### PR TITLE
Let Dependabot handle Python dependencies in skeleton and comment out Terraform portion from Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,6 @@ updates:
   - directory: /
     # ignore:
     #   # Managed by cisagov/skeleton-generic
-    #   - dependency-name: ipython
     #   - dependency-name: pre-commit
     #   - dependency-name: semver
     #   - dependency-name: setuptools

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,8 +42,9 @@ updates:
     schedule:
       interval: weekly
 
-  - directory: /
-    package-ecosystem: terraform
-    schedule:
-      interval: weekly
+  # Uncomment this section if you have Terraform code in your project.
+  # - directory: /
+  #   package-ecosystem: terraform
+  #   schedule:
+  #     interval: weekly
 version: 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,12 @@ updates:
       interval: weekly
 
   - directory: /
+    # ignore:
+    #   # Managed by cisagov/skeleton-generic
+    #   - dependency-name: ipython
+    #   - dependency-name: pre-commit
+    #   - dependency-name: semver
+    #   - dependency-name: setuptools
     package-ecosystem: pip
     schedule:
       interval: weekly

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 --requirement requirements-test.txt
-ipython
 # The bump-version script requires at least version 3 of semver.
 semver>=3


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Adds (commented-out) Dependabot ignore directives for Python dependencies
- Removes the Terraform section from the Dependabot configuration
- Removes iPython as a dependency

## 💭 Motivation and context ##

- These dependencies should be handled at the skeleton level so we don't get a million PRs for them in the descendants.
- There is no Terraform code in this skeleton, so including such a section results in [needless Dependabot runs that fail anyway](https://github.com/cisagov/skeleton-generic/actions/runs/24689486456).
- There is no Python code in this repository, so users are unlikely to be interacting with a Python prompt via iPython.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
