### PR TITLE
Add major, minor, and patch labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -56,7 +56,7 @@
 - color: ff0000
   description: The changes in this pull request call for a major version bump
   name: major
-- color: 0000ff
+- color: 00ff00
   description: The changes in this pull request call for a minor version bump
   name: minor
 - color: a4fc5d
@@ -68,7 +68,7 @@
 - color: 02a8ef
   description: Pull requests that update Packer code
   name: packer
-- color: 00ff00
+- color: 0000ff
   description: The changes in this pull request call for a patch version bump
   name: patch
 - color: 3776ab

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -53,6 +53,12 @@
 - color: ce099a
   description: This pull request is ready to merge during the next Lineage Kraken release
   name: kraken 🐙
+- color: ff0000
+  description: This changes in this pull request call for a major version bump
+  name: major
+- color: 0000ff
+  description: This changes in this pull request call for a minor version bump
+  name: minor
 - color: a4fc5d
   description: This issue or pull request requires further information
   name: need info
@@ -62,6 +68,9 @@
 - color: 02a8ef
   description: Pull requests that update Packer code
   name: packer
+- color: 00ff00
+  description: This changes in this pull request call for a patch version bump
+  name: patch
 - color: 3776ab
   description: Pull requests that update Python code
   name: python

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -54,10 +54,10 @@
   description: This pull request is ready to merge during the next Lineage Kraken release
   name: kraken 🐙
 - color: ff0000
-  description: This changes in this pull request call for a major version bump
+  description: The changes in this pull request call for a major version bump
   name: major
 - color: 0000ff
-  description: This changes in this pull request call for a minor version bump
+  description: The changes in this pull request call for a minor version bump
   name: minor
 - color: a4fc5d
   description: This issue or pull request requires further information
@@ -69,7 +69,7 @@
   description: Pull requests that update Packer code
   name: packer
 - color: 00ff00
-  description: This changes in this pull request call for a patch version bump
+  description: The changes in this pull request call for a patch version bump
   name: patch
 - color: 3776ab
   description: Pull requests that update Python code


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds `major`, `minor`, and `patch` GitHub labels.

## 💭 Motivation and context ##

These labels are intended to be used to mark when PRs call for a major, minor, or patch version bump.  Use of these labels should make it easier to determine the necessary version bump when creating a release that involves multiple PRs; simply note the label corresponding to the highest version bump and bump the version accordingly.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
