### PR TITLE
Upgrade and override `language_version` for the `ansible-lint` `pre-commit` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -220,7 +220,7 @@ repos:
         # https://github.com/ansible/ansible-lint/blob/eefc3626bb341032d5a80288735cca6441c9c873/pyproject.toml#L9
         # [3]:
         # https://github.com/cisagov/setup-env-github-action/blob/8567c2291ccdf5b84c297b487f592606f3af214f/src/versions.js#L27
-        language_version: "3.13"
+        language_version: python3.13
 
   # Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -182,10 +182,7 @@ repos:
 
   # Ansible hooks
   - repo: https://github.com/ansible/ansible-lint
-    # We need to stay on this version because we are still using Python 3.13 in
-    # our GitHub Actions configuration. Later versions require Python 3.14 for
-    # the hook to run.
-    rev: v26.1.1
+    rev: v26.4.0
     hooks:
       - id: ansible-lint
         additional_dependencies:
@@ -208,6 +205,22 @@ repos:
           # made in requirements.txt in cisagov/skeleton-packer and
           # requirements-test.txt in cisagov/skeleton-ansible-role.
           - ansible-core>=2.17.7
+        # We are still using Python 3.13 in our GitHub Actions
+        # configuration, but after version v26.1.1 of this pre-commit
+        # hook language_version is (somewhat unnecessarily but
+        # understandably[1]) hard coded to Python 3.14.  ansible-lint
+        # itself currently supports Python>=3.10[2].
+        #
+        # Note that this version must stay in sync with the Python
+        # version specified in cisagov/setup-env-github-action[3].
+        #
+        # [1]:
+        # https://github.com/ansible/ansible-lint/issues/4812#issuecomment-3382337336
+        # [2]:
+        # https://github.com/ansible/ansible-lint/blob/eefc3626bb341032d5a80288735cca6441c9c873/pyproject.toml#L9
+        # [3]:
+        # https://github.com/cisagov/setup-env-github-action/blob/8567c2291ccdf5b84c297b487f592606f3af214f/src/versions.js#L27
+        language_version: "3.13"
 
   # Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades the version of the `ansible-lint` `pre-commit` hook.

See also:
- cisagov/skeleton-ansible-role#257
- cisagov/setup-env-github-action#123.

## 💭 Motivation and context ##

This same change is required in cisagov/skeleton-ansible-role#257, so we should make it in the upstream skeleton as well.

We are still using Python 3.13 in our GitHub Actions configuration, but after version v26.1.1 of the `ansible-lint` `pre-commit` hook `language_version` is ([somewhat unnecessarily but understandably][1]) hard coded to Python 3.14.  `ansible-lint` itself [currently supports Python>=3.10][2].

Note that this version must stay in sync with the [Python version specified in cisagov/setup-env-github-action][3].

[1]: https://github.com/ansible/ansible-lint/issues/4812#issuecomment-3382337336
[2]: https://github.com/ansible/ansible-lint/blob/eefc3626bb341032d5a80288735cca6441c9c873/pyproject.toml#L9
[^3]: https://github.com/cisagov/setup-env-github-action/blob/8567c2291ccdf5b84c297b487f592606f3af214f/src/versions.js#L27

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.