### PR TITLE
Add pre-commit hooks to use terraform-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -252,3 +252,12 @@ repos:
     hooks:
       - id: packer_fmt
       - id: packer_validate
+  # We're using terraform-docs to generate Packer template documentation
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.105.0
+    hooks:
+      - id: terraform_docs
+        # Override the files to run against Packer templates
+        files: \.pkr\.hcl
+        # Override the name to include mention of Packer
+        name: Terraform docs (Packer templates)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -227,6 +227,7 @@ repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.105.0
     hooks:
+      - id: terraform_docs
       - id: terraform_fmt
       - id: terraform_validate
       # This needs to run after the terraform_validate hook so that any Terraform


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a pre-commit hook to generate documentation for Terraform configurations using [terraform-docs](https://github.com/terraform-docs/terraform-docs). It also adds a pre-commit hook to the same for Packer templates.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This will ensure that changes will automatically have appropriate documentation generated.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I made changes to the Packer template and `terraform-post-packer/` Terraform configuration in [cisagov/skeleton-packer](https://github.com/cisagov/skeleton-packer) locally and ran pre-commit against the project. I saw appropriate changes to the respective READMEs that indicated the hooks were working as expected.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
