### PR TITLE
Switch `versioning-strategy` to `increase-if-necessary` for `pip` section of Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,7 @@ updates:
     package-ecosystem: pip
     schedule:
       interval: weekly
+    versioning-strategy: increase-if-necessary
 
   - directory: /
     package-ecosystem: terraform


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the `versioning-strategy` to `increase-if-necessary` for the `pip` section of the Dependabot configuration.

## 💭 Motivation and context ##

This choice should help with PRs such as cisagov/skeleton-generic#279 and cisagov/code-gov-update#311, where previously Dependabot wanted to incorrectly force the new version as a lower bound constraint into the `Pipfile` or `requirements.txt` file.

According to the AIs:

You would choose `increase-if-necessary` over `lockfile-only` when you want Dependabot to automatically update your manifest file (e.g., `package.json`, `Cargo.toml`) whenever a new dependency version falls outside your currently defined semantic version (semver) range.

It makes sense to use `lockfile-only` instead of `increase-if-necessary` when your primary goal is to minimize manifest churn and you prefer to handle major or breaking dependency upgrades manually.

Choose `lockfile-only` if:
- You only want automated PRs for security and bug fixes.
- You want zero changes to your main manifest file from bots.
- You prefer upgrading major tools (like upgrading from Webpack 4 to 5) manually.

Choose increase-if-necessary if:
- You want the bot to handle both security patches and major version upgrades automatically.

## 🧪 Testing ##

All automated tests pass.  The real test happens when this is merged and Dependabot does its thang.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.