### PR TITLE
Add a Renovate config that points to the org baseline preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,3 @@
+{
+  extends: ["github>cisagov/renovate-config"],
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a Renovate configuration that simply points to the GitHub organization's baseline preset.

See also cisagov/renovate-config#1.

## 💭 Motivation and context ##

We need the Renovate regex manager to handle dependencies that Dependabot cannot; this gives us a generic way to do that.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.